### PR TITLE
:book: Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+<!--
+Thanks for creating a pull request!
+
+If this is your first time, please make sure to review CONTRIBUTING.MD.
+
+Please copy the appropriate `:text:` or icon to the beginning of your PR title:
+
+:sparkles: ✨ feature
+:bug: 🐛 bug fix
+:book: 📖 docs
+:memo: 📝 proposal
+:warning: ⚠️ breaking change
+:seedling: 🌱 other/misc
+:question: ❓ requires manual review/categorization
+
+-->
+## Summary
+
+## Related issue(s)
+
+Fixes #
+
+## Release Notes
+
+<!--
+Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
+-->
+
+```release-note
+NONE
+```


### PR DESCRIPTION
## Summary

I forgot to add the pull request template in #1, but the active Prow configuration requires the release note block. This fixes that oversight and copies the pull request template from kcp-dev/kcp.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```