### PR TITLE
🐛 fix rootshard URL not pointing to its service

### DIFF
--- a/api/v1alpha1/rootshard_types.go
+++ b/api/v1alpha1/rootshard_types.go
@@ -115,7 +115,7 @@ func (r *RootShard) GetShardBaseURL() string {
 		clusterDomain = "cluster.local"
 	}
 
-	return fmt.Sprintf("https://%s.%s.svc.%s:6443", r.Name, r.Namespace, clusterDomain)
+	return fmt.Sprintf("https://%s-kcp.%s.svc.%s:6443", r.Name, r.Namespace, clusterDomain)
 }
 
 type Certificate string

--- a/internal/resources/kubeconfig/secret.go
+++ b/internal/resources/kubeconfig/secret.go
@@ -28,7 +28,7 @@ import (
 	"github.com/kcp-dev/kcp-operator/api/v1alpha1"
 )
 
-func KubeconfigSecretReconciler(kubeconfig *v1alpha1.Kubeconfig, certSecret *corev1.Secret, serverName, serverUrl string) reconciling.NamedSecretReconcilerFactory {
+func KubeconfigSecretReconciler(kubeconfig *v1alpha1.Kubeconfig, certSecret *corev1.Secret, serverName, serverURL string) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
 		return kubeconfig.Spec.SecretRef.Name, func(secret *corev1.Secret) (*corev1.Secret, error) {
 			var config *clientcmdapi.Config
@@ -41,7 +41,7 @@ func KubeconfigSecretReconciler(kubeconfig *v1alpha1.Kubeconfig, certSecret *cor
 
 			config.Clusters = map[string]*clientcmdapi.Cluster{
 				serverName: {
-					Server:                   serverUrl,
+					Server:                   serverURL,
 					CertificateAuthorityData: certSecret.Data["ca.crt"],
 				},
 			}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -180,9 +180,6 @@ func ConnectWithKubeconfig(
 	parts := strings.Split(hostname, ".")
 	serviceName := parts[0]
 
-	// HACK/workaround: service name in URL is wrong
-	serviceName += "-kcp"
-
 	portNum, err := strconv.ParseInt(portString, 10, 32)
 	if err != nil {
 		t.Fatalf("Failed to parse kubeconfig's port %q: %v", portString, err)


### PR DESCRIPTION
## Summary
The URL in the generated kubeconfig did not correctly point to the _Service_, but to the RootShard object (kind of). It's a bit sad that we hardcoded such things into our API, which now depends on secret knowledge of the service reconciler (i.e. the APIs package knows how the resources package calls something... which is not ideal).

## Release Notes
```release-note
Fix RootShard URL in generated kubeconfigs.
```
