### PR TITLE
✨ bump to Go 1.23.4

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,9 +19,9 @@ issues:
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - dupl
     - errcheck
-    - exportloopref
     - ginkgolinter
     - goconst
     - gocyclo

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.4-3
           command:
             - make
             - verify
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.4-3
           command:
             - make
             - lint
@@ -63,7 +63,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.4-3
           command:
             - make
             - test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.22.9 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.23.4 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ENVTEST_K8S_VERSION = 1.31.0
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.16.1
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v1.59.1
+GOLANGCI_LINT_VERSION ?= v1.63.4
 
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/kcp-dev/kcp-operator


### PR DESCRIPTION
## Summary
Go 1.24 is around the corner, time to update to 1.23 at least.

## Release Notes
```release-note
Update to Go 1.23.4.
```
