### PR TITLE
✨ Add phase and owner references to RootShards

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -49,7 +49,7 @@ type ImageSpec struct {
 
 type RootShardConfig struct {
 	// Reference references a local RootShard object.
-	Reference *corev1.ObjectReference `json:"ref,omitempty"`
+	Reference *corev1.LocalObjectReference `json:"ref,omitempty"`
 }
 
 type EtcdConfig struct {

--- a/api/v1alpha1/rootshard_types.go
+++ b/api/v1alpha1/rootshard_types.go
@@ -84,12 +84,28 @@ type OIDCConfiguration struct {
 
 // RootShardStatus defines the observed state of RootShard
 type RootShardStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	Phase RootShardPhase `json:"phase,omitempty"`
 }
+
+type RootShardPhase string
+
+const (
+	RootShardPhaseProvisioning RootShardPhase = "Provisioning"
+	RootShardPhaseRunning      RootShardPhase = "Running"
+	RootShardPhaseDeleting     RootShardPhase = "Deleting"
+)
+
+type RootShardConditionType string
+
+const (
+	RootShardConditionTypeAvailable RootShardConditionType = "Available"
+)
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:JSONPath=".spec.external.hostname",name="Hostname",type="string"
+// +kubebuilder:printcolumn:JSONPath=".status.phase",name="Phase",type="string"
+// +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type="date"
 
 // RootShard is the Schema for the kcpinstances API
 type RootShard struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -591,7 +591,7 @@ func (in *RootShardConfig) DeepCopyInto(out *RootShardConfig) {
 	*out = *in
 	if in.Reference != nil {
 		in, out := &in.Reference, &out.Reference
-		*out = new(v1.ObjectReference)
+		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
 }

--- a/config/crd/bases/operator.kcp.io_frontproxies.yaml
+++ b/config/crd/bases/operator.kcp.io_frontproxies.yaml
@@ -98,43 +98,14 @@ spec:
                   ref:
                     description: Reference references a local RootShard object.
                     properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: |-
-                          If referring to a piece of an object instead of an entire object, this string
-                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within a pod, this would take on a value like:
-                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]" (container with
-                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
-                          referencing a part of an object.
-                        type: string
-                      kind:
-                        description: |-
-                          Kind of the referent.
-                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        type: string
-                      namespace:
-                        description: |-
-                          Namespace of the referent.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                        type: string
-                      resourceVersion:
-                        description: |-
-                          Specific resourceVersion to which this reference is made, if any.
-                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                        type: string
-                      uid:
-                        description: |-
-                          UID of the referent.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic

--- a/config/crd/bases/operator.kcp.io_rootshards.yaml
+++ b/config/crd/bases/operator.kcp.io_rootshards.yaml
@@ -14,7 +14,17 @@ spec:
     singular: rootshard
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.external.hostname
+      name: Hostname
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: RootShard is the Schema for the kcpinstances API
@@ -188,6 +198,9 @@ spec:
             type: object
           status:
             description: RootShardStatus defines the observed state of RootShard
+            properties:
+              phase:
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/operator.kcp.io_shards.yaml
+++ b/config/crd/bases/operator.kcp.io_shards.yaml
@@ -120,43 +120,14 @@ spec:
                   ref:
                     description: Reference references a local RootShard object.
                     properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: |-
-                          If referring to a piece of an object instead of an entire object, this string
-                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within a pod, this would take on a value like:
-                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]" (container with
-                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
-                          referencing a part of an object.
-                        type: string
-                      kind:
-                        description: |-
-                          Kind of the referent.
-                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        type: string
-                      namespace:
-                        description: |-
-                          Namespace of the referent.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                        type: string
-                      resourceVersion:
-                        description: |-
-                          Specific resourceVersion to which this reference is made, if any.
-                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                        type: string
-                      uid:
-                        description: |-
-                          UID of the referent.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic

--- a/internal/controller/rootshard_controller.go
+++ b/internal/controller/rootshard_controller.go
@@ -66,7 +66,12 @@ func (r *RootShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	var rootShard v1alpha1.RootShard
 	if err := r.Client.Get(ctx, req.NamespacedName, &rootShard); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to find %s/%s: %w", req.Namespace, req.Name, err)
+		if client.IgnoreNotFound(err) != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to find %s/%s: %w", req.Namespace, req.Name, err)
+		}
+
+		// Object has apparently been deleted already.
+		return ctrl.Result{}, nil
 	}
 
 	if rootShard.DeletionTimestamp != nil {

--- a/internal/controller/rootshard_controller.go
+++ b/internal/controller/rootshard_controller.go
@@ -88,7 +88,7 @@ func (r *RootShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	ownerRefWrapper := k8creconciling.OwnerRefWrapper(*metav1.NewControllerRef(&rootShard, operatorkcpiov1alpha1.GroupVersion.WithKind(rootShard.Kind)))
+	ownerRefWrapper := k8creconciling.OwnerRefWrapper(*metav1.NewControllerRef(&rootShard, operatorkcpiov1alpha1.GroupVersion.WithKind("RootShard")))
 
 	// Intermediate CAs that we need to generate a certificate and an issuer for.
 	intermediateCAs := []v1alpha1.CA{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This adds a basic `.status.phase` field to `RootShards` that will indicate what part of the lifecycle the object is in. In addition, this PR adds owner references on all objects created by a `RootShard` object. As a minor addition, it also adds custom print columns for a nicer experience when running `kubectl get rootshards`.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add `status.phase` to `RootShards` and set up owner references on all child objects
```
