### PR TITLE
🐛 fix missing pod.ns.svc.cluster.local hostname in kcp server cert

### DIFF
--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -70,13 +70,17 @@ func GetRootShardResourceLabels(r *v1alpha1.RootShard) map[string]string {
 	}
 }
 
-func GetRootShardBaseURL(r *v1alpha1.RootShard) string {
+func GetRootShardBaseHost(r *v1alpha1.RootShard) string {
 	clusterDomain := r.Spec.ClusterDomain
 	if clusterDomain == "" {
 		clusterDomain = "cluster.local"
 	}
 
-	return fmt.Sprintf("https://%s-kcp.%s.svc.%s:6443", r.Name, r.Namespace, clusterDomain)
+	return fmt.Sprintf("%s-kcp.%s.svc.%s", r.Name, r.Namespace, clusterDomain)
+}
+
+func GetRootShardBaseURL(r *v1alpha1.RootShard) string {
+	return fmt.Sprintf("https://%s:6443", GetRootShardBaseHost(r))
 }
 
 func GetRootShardCertificateName(r *v1alpha1.RootShard, certName v1alpha1.Certificate) string {

--- a/internal/resources/rootshard/certificates.go
+++ b/internal/resources/rootshard/certificates.go
@@ -47,6 +47,7 @@ func ServerCertificateReconciler(rootShard *operatorv1alpha1.RootShard) reconcil
 
 				DNSNames: []string{
 					"localhost",
+					resources.GetRootShardBaseHost(rootShard),
 					rootShard.Spec.External.Hostname,
 				},
 


### PR DESCRIPTION
## Summary
When talking to kcp, clients usually use the Service we provide. This means the cert for the server needs to include that service name.

## Release Notes
```release-note
Fix missing hostname in kcp server certificate.
```
