### PR TITLE
✨ Add volume revision labels for automatic rollouts

### DIFF
--- a/internal/controller/frontproxy_controller.go
+++ b/internal/controller/frontproxy_controller.go
@@ -71,7 +71,7 @@ func (r *FrontProxyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *FrontProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, recErr error) {
 	logger := log.FromContext(ctx)
-	logger.Info("Reconciling FrontProxy object")
+	logger.V(4).Info("Reconciling")
 
 	var frontProxy operatorv1alpha1.FrontProxy
 	if err := r.Client.Get(ctx, req.NamespacedName, &frontProxy); err != nil {

--- a/internal/controller/frontproxy_controller.go
+++ b/internal/controller/frontproxy_controller.go
@@ -58,6 +58,7 @@ func (r *FrontProxyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.Service{}).
 		Owns(&certmanagerv1.Certificate{}).
+		Watches(&corev1.Secret{}, newSecretGrandchildWatcher(resources.FrontProxyLabel)).
 		Complete(r)
 }
 

--- a/internal/controller/frontproxy_controller.go
+++ b/internal/controller/frontproxy_controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
+	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
 	"github.com/kcp-dev/kcp-operator/internal/resources"
 	"github.com/kcp-dev/kcp-operator/internal/resources/frontproxy"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
@@ -140,7 +141,7 @@ func (r *FrontProxyReconciler) reconcile(ctx context.Context, frontProxy *operat
 		errs = append(errs, err)
 	}
 
-	if err := k8creconciling.ReconcileDeployments(ctx, deploymentReconcilers, frontProxy.Namespace, r.Client, ownerRefWrapper); err != nil {
+	if err := k8creconciling.ReconcileDeployments(ctx, deploymentReconcilers, frontProxy.Namespace, r.Client, ownerRefWrapper, modifier.RelatedRevisionsLabels(ctx, r.Client)); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/internal/controller/kubeconfig_controller.go
+++ b/internal/controller/kubeconfig_controller.go
@@ -45,6 +45,15 @@ type KubeconfigReconciler struct {
 	Scheme *runtime.Scheme
 }
 
+// SetupWithManager sets up the controller with the Manager.
+func (r *KubeconfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&operatorv1alpha1.Kubeconfig{}).
+		Owns(&corev1.Secret{}).
+		Owns(&certmanagerv1.Certificate{}).
+		Complete(r)
+}
+
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=kubeconfigs,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=kubeconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=kubeconfigs/finalizers,verbs=update
@@ -139,11 +148,4 @@ func (r *KubeconfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	return ctrl.Result{}, nil
-}
-
-// SetupWithManager sets up the controller with the Manager.
-func (r *KubeconfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&operatorv1alpha1.Kubeconfig{}).
-		Complete(r)
 }

--- a/internal/controller/kubeconfig_controller.go
+++ b/internal/controller/kubeconfig_controller.go
@@ -51,6 +51,7 @@ func (r *KubeconfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&operatorv1alpha1.Kubeconfig{}).
 		Owns(&corev1.Secret{}).
 		Owns(&certmanagerv1.Certificate{}).
+		Watches(&corev1.Secret{}, newSecretGrandchildWatcher(resources.KubeconfigLabel)).
 		Complete(r)
 }
 

--- a/internal/controller/rootshard_controller.go
+++ b/internal/controller/rootshard_controller.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
+	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
 	"github.com/kcp-dev/kcp-operator/internal/resources"
 	"github.com/kcp-dev/kcp-operator/internal/resources/rootshard"
 	"github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
@@ -137,7 +138,7 @@ func (r *RootShardReconciler) reconcile(ctx context.Context, rootShard *operator
 
 	if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{
 		rootshard.DeploymentReconciler(rootShard),
-	}, rootShard.Namespace, r.Client, ownerRefWrapper); err != nil {
+	}, rootShard.Namespace, r.Client, ownerRefWrapper, modifier.RelatedRevisionsLabels(ctx, r.Client)); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/internal/controller/rootshard_controller.go
+++ b/internal/controller/rootshard_controller.go
@@ -82,7 +82,7 @@ func (r *RootShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.0/pkg/reconcile
 func (r *RootShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, recErr error) {
 	logger := log.FromContext(ctx)
-	logger.Info("Reconciling RootShard object")
+	logger.V(4).Info("Reconciling")
 
 	var rootShard v1alpha1.RootShard
 	if err := r.Client.Get(ctx, req.NamespacedName, &rootShard); err != nil {

--- a/internal/controller/rootshard_controller.go
+++ b/internal/controller/rootshard_controller.go
@@ -56,7 +56,6 @@ func (r *RootShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&operatorv1alpha1.RootShard{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.ConfigMap{}).
-		Owns(&corev1.Secret{}).
 		Owns(&corev1.Service{}).
 		Owns(&certmanagerv1.Certificate{}).
 		Watches(&corev1.Secret{}, newSecretGrandchildWatcher(resources.RootShardLabel)).
@@ -70,6 +69,7 @@ func (r *RootShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=cert-manager.io,resources=issuers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/rootshard_controller.go
+++ b/internal/controller/rootshard_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	k8creconciling "k8c.io/reconciler/pkg/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -35,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
 	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
 	"github.com/kcp-dev/kcp-operator/internal/resources"
@@ -59,6 +59,7 @@ func (r *RootShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.Service{}).
 		Owns(&certmanagerv1.Certificate{}).
+		Watches(&corev1.Secret{}, newSecretGrandchildWatcher(resources.RootShardLabel)).
 		Complete(r)
 }
 

--- a/internal/controller/rootshard_controller.go
+++ b/internal/controller/rootshard_controller.go
@@ -23,6 +23,7 @@ import (
 	k8creconciling "k8c.io/reconciler/pkg/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
 	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
 	"github.com/kcp-dev/kcp-operator/internal/resources"
@@ -53,6 +55,10 @@ func (r *RootShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&operatorv1alpha1.RootShard{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Secret{}).
+		Owns(&corev1.Service{}).
+		Owns(&certmanagerv1.Certificate{}).
 		Complete(r)
 }
 

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func newSecretGrandchildWatcher(labelKey string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		grandparent, ok := obj.GetLabels()[labelKey]
+		if !ok {
+			return nil
+		}
+
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{
+				Name:      grandparent,
+				Namespace: obj.GetNamespace(),
+			},
+		}}
+	})
+}

--- a/internal/kubernetes/metadata.go
+++ b/internal/kubernetes/metadata.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"maps"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// HasFinalizer tells if a object has all the given finalizers.
+func HasFinalizer(o metav1.Object, names ...string) bool {
+	return sets.New(o.GetFinalizers()...).HasAll(names...)
+}
+
+func HasAnyFinalizer(o metav1.Object, names ...string) bool {
+	return sets.New(o.GetFinalizers()...).HasAny(names...)
+}
+
+// HasOnlyFinalizer tells if an object has only the given finalizer(s).
+func HasOnlyFinalizer(o metav1.Object, names ...string) bool {
+	return sets.New(o.GetFinalizers()...).Equal(sets.New(names...))
+}
+
+// HasFinalizerSuperset tells if the given finalizer(s) are a superset
+// of the actual finalizers.
+func HasFinalizerSuperset(o metav1.Object, names ...string) bool {
+	return sets.New(names...).IsSuperset(sets.New(o.GetFinalizers()...))
+}
+
+// RemoveFinalizer removes the given finalizers from the object.
+func RemoveFinalizer(obj metav1.Object, toRemove ...string) {
+	set := sets.New(obj.GetFinalizers()...)
+	set.Delete(toRemove...)
+	obj.SetFinalizers(sets.List(set))
+}
+
+func EnsureLabels(o metav1.Object, toEnsure map[string]string) {
+	labels := maps.Clone(o.GetLabels())
+
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	for key, value := range toEnsure {
+		labels[key] = value
+	}
+	o.SetLabels(labels)
+}
+
+func EnsureAnnotations(o metav1.Object, toEnsure map[string]string) {
+	annotations := maps.Clone(o.GetAnnotations())
+
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	for key, value := range toEnsure {
+		annotations[key] = value
+	}
+	o.SetAnnotations(annotations)
+}

--- a/internal/kubernetes/metadata.go
+++ b/internal/kubernetes/metadata.go
@@ -20,35 +20,7 @@ import (
 	"maps"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
-
-// HasFinalizer tells if a object has all the given finalizers.
-func HasFinalizer(o metav1.Object, names ...string) bool {
-	return sets.New(o.GetFinalizers()...).HasAll(names...)
-}
-
-func HasAnyFinalizer(o metav1.Object, names ...string) bool {
-	return sets.New(o.GetFinalizers()...).HasAny(names...)
-}
-
-// HasOnlyFinalizer tells if an object has only the given finalizer(s).
-func HasOnlyFinalizer(o metav1.Object, names ...string) bool {
-	return sets.New(o.GetFinalizers()...).Equal(sets.New(names...))
-}
-
-// HasFinalizerSuperset tells if the given finalizer(s) are a superset
-// of the actual finalizers.
-func HasFinalizerSuperset(o metav1.Object, names ...string) bool {
-	return sets.New(names...).IsSuperset(sets.New(o.GetFinalizers()...))
-}
-
-// RemoveFinalizer removes the given finalizers from the object.
-func RemoveFinalizer(obj metav1.Object, toRemove ...string) {
-	set := sets.New(obj.GetFinalizers()...)
-	set.Delete(toRemove...)
-	obj.SetFinalizers(sets.List(set))
-}
 
 func EnsureLabels(o metav1.Object, toEnsure map[string]string) {
 	labels := maps.Clone(o.GetLabels())

--- a/internal/reconciling/modifier/related_revisions.go
+++ b/internal/reconciling/modifier/related_revisions.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modifier
+
+import (
+	"context"
+	"fmt"
+
+	"k8c.io/reconciler/pkg/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kcp-dev/kcp-operator/internal/kubernetes"
+)
+
+// RelatedRevisionsLabels scans volume mounts for pod templates for ConfigMaps
+// and Secrets and will then put new labels for these mounts onto the pod template, causing
+// restarts when the volumes changed.
+func RelatedRevisionsLabels(ctx context.Context, client ctrlruntimeclient.Client) reconciling.ObjectModifier {
+	return func(reconciler reconciling.ObjectReconciler) reconciling.ObjectReconciler {
+		return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+			obj, err := reconciler(existing)
+			if err != nil {
+				return obj, err
+			}
+
+			return addRevisionLabelsToObject(ctx, client, obj)
+		}
+	}
+}
+
+func addRevisionLabelsToObject(ctx context.Context, client ctrlruntimeclient.Client, obj ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+	switch asserted := obj.(type) {
+	case *appsv1.Deployment:
+		if err := addRevisionLabelsToPodSpec(ctx, client, asserted.Namespace, &asserted.Spec.Template); err != nil {
+			return nil, fmt.Errorf("failed to determine revision labels: %w", err)
+		}
+
+	case *appsv1.StatefulSet:
+		if err := addRevisionLabelsToPodSpec(ctx, client, asserted.Namespace, &asserted.Spec.Template); err != nil {
+			return nil, fmt.Errorf("failed to determine revision labels: %w", err)
+		}
+
+	case *appsv1.DaemonSet:
+		if err := addRevisionLabelsToPodSpec(ctx, client, asserted.Namespace, &asserted.Spec.Template); err != nil {
+			return nil, fmt.Errorf("failed to determine revision labels: %w", err)
+		}
+
+	default:
+		panic(fmt.Sprintf("RelatedRevisionsLabels modifier used on incompatible type %T", obj))
+	}
+
+	return obj, nil
+}
+
+func addRevisionLabelsToPodSpec(ctx context.Context, client ctrlruntimeclient.Client, namespace string, ps *corev1.PodTemplateSpec) error {
+	allContainers := []corev1.Container{}
+	allContainers = append(allContainers, ps.Spec.InitContainers...)
+	allContainers = append(allContainers, ps.Spec.Containers...)
+
+	revisionLabels, err := getRelatedRevisionLabels(ctx, client, namespace, ps.Spec.Volumes, allContainers)
+	if err != nil {
+		return err
+	}
+
+	kubernetes.EnsureLabels(ps, revisionLabels)
+
+	return nil
+}
+
+// getRelatedRevisionLabels returns a set of labels for the given volumes/containers,
+// with one label per ConfigMap or Secret, containing the objects' revisions.
+// When used for pod template labels, this will force pods being restarted as soon as one
+// of the secrets/configmaps get updated.
+func getRelatedRevisionLabels(
+	ctx context.Context,
+	client ctrlruntimeclient.Client,
+	namespace string,
+	volumes []corev1.Volume,
+	containers []corev1.Container,
+) (map[string]string, error) {
+	labels := make(map[string]string)
+
+	loadSecret := func(name string, optional bool) error {
+		labelName := fmt.Sprintf("%s-secret-revision", name)
+
+		// skip checking the same secret again
+		if _, ok := labels[labelName]; ok {
+			return nil
+		}
+
+		key := types.NamespacedName{Namespace: namespace, Name: name}
+		revision, err := secretRevision(ctx, client, key)
+		if err != nil {
+			if optional && apierrors.IsNotFound(err) {
+				return nil
+			}
+
+			return err
+		}
+
+		labels[labelName] = revision
+
+		return nil
+	}
+
+	loadConfigMap := func(name string, optional bool) error {
+		labelName := fmt.Sprintf("%s-configmap-revision", name)
+
+		// skip checking the same ConfigMap again
+		if _, ok := labels[labelName]; ok {
+			return nil
+		}
+
+		key := types.NamespacedName{Namespace: namespace, Name: name}
+		revision, err := configMapRevision(ctx, client, key)
+		if err != nil {
+			if optional && apierrors.IsNotFound(err) {
+				return nil
+			}
+
+			return err
+		}
+
+		labels[labelName] = revision
+
+		return nil
+	}
+
+	for _, v := range volumes {
+		if v.VolumeSource.Secret != nil {
+			if err := loadSecret(v.VolumeSource.Secret.SecretName, false); err != nil {
+				return nil, err
+			}
+		}
+
+		if v.VolumeSource.ConfigMap != nil {
+			if err := loadConfigMap(v.VolumeSource.ConfigMap.Name, false); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	for _, c := range containers {
+		for _, e := range c.Env {
+			if source := e.ValueFrom; source != nil {
+				if cm := source.ConfigMapKeyRef; cm != nil {
+					if err := loadConfigMap(cm.Name, cm.Optional != nil && *cm.Optional); err != nil {
+						return nil, err
+					}
+				}
+
+				if sec := source.SecretKeyRef; sec != nil {
+					if err := loadSecret(sec.Name, sec.Optional != nil && *sec.Optional); err != nil {
+						return nil, err
+					}
+				}
+			}
+		}
+
+		for _, e := range c.EnvFrom {
+			if cm := e.ConfigMapRef; cm != nil {
+				if err := loadConfigMap(cm.Name, cm.Optional != nil && *cm.Optional); err != nil {
+					return nil, err
+				}
+			}
+
+			if sec := e.SecretRef; sec != nil {
+				if err := loadSecret(sec.Name, sec.Optional != nil && *sec.Optional); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	return labels, nil
+}
+
+// secretRevision returns the resource version of the Secret specified by name.
+func secretRevision(ctx context.Context, client ctrlruntimeclient.Client, key types.NamespacedName) (string, error) {
+	secret := &corev1.Secret{}
+	err := client.Get(ctx, key, secret)
+
+	return secret.ResourceVersion, err
+}
+
+// configMapRevision returns the resource version of the ConfigMap specified by name.
+func configMapRevision(ctx context.Context, client ctrlruntimeclient.Client, key types.NamespacedName) (string, error) {
+	cm := &corev1.ConfigMap{}
+	err := client.Get(ctx, key, cm)
+
+	return cm.ResourceVersion, err
+}

--- a/internal/resources/frontproxy/certificates.go
+++ b/internal/resources/frontproxy/certificates.go
@@ -40,7 +40,13 @@ func ServerCertificateReconciler(frontProxy *operatorv1alpha1.FrontProxy, rootSh
 		return name, func(cert *certmanagerv1.Certificate) (*certmanagerv1.Certificate, error) {
 			cert.SetLabels(resources.GetFrontProxyResourceLabels(frontProxy))
 			cert.Spec = certmanagerv1.CertificateSpec{
-				SecretName:  name,
+				SecretName: name,
+				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
+					Labels: map[string]string{
+						resources.RootShardLabel:  rootshard.Name,
+						resources.FrontProxyLabel: frontproxy.Name,
+					},
+				},
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
 				RenewBefore: &operatorv1alpha1.DefaultCertificateRenewal,
 
@@ -74,7 +80,13 @@ func AdminKubeconfigCertificateReconciler(frontProxy *operatorv1alpha1.FrontProx
 		return name, func(cert *certmanagerv1.Certificate) (*certmanagerv1.Certificate, error) {
 			cert.SetLabels(resources.GetFrontProxyResourceLabels(frontProxy))
 			cert.Spec = certmanagerv1.CertificateSpec{
-				SecretName:  name,
+				SecretName: name,
+				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
+					Labels: map[string]string{
+						resources.RootShardLabel:  rootshard.Name,
+						resources.FrontProxyLabel: frontproxy.Name,
+					},
+				},
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
 				RenewBefore: &operatorv1alpha1.DefaultCertificateRenewal,
 
@@ -112,7 +124,13 @@ func KubeconfigCertificateReconciler(frontProxy *operatorv1alpha1.FrontProxy, ro
 		return name, func(cert *certmanagerv1.Certificate) (*certmanagerv1.Certificate, error) {
 			cert.SetLabels(resources.GetFrontProxyResourceLabels(frontProxy))
 			cert.Spec = certmanagerv1.CertificateSpec{
-				SecretName:  name,
+				SecretName: name,
+				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
+					Labels: map[string]string{
+						resources.RootShardLabel:  rootshard.Name,
+						resources.FrontProxyLabel: frontproxy.Name,
+					},
+				},
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
 				RenewBefore: &operatorv1alpha1.DefaultCertificateRenewal,
 
@@ -150,7 +168,13 @@ func RequestHeaderCertificateReconciler(frontProxy *operatorv1alpha1.FrontProxy,
 		return name, func(cert *certmanagerv1.Certificate) (*certmanagerv1.Certificate, error) {
 			cert.SetLabels(resources.GetFrontProxyResourceLabels(frontProxy))
 			cert.Spec = certmanagerv1.CertificateSpec{
-				SecretName:  name,
+				SecretName: name,
+				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
+					Labels: map[string]string{
+						resources.RootShardLabel:  rootshard.Name,
+						resources.FrontProxyLabel: frontproxy.Name,
+					},
+				},
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
 				RenewBefore: &operatorv1alpha1.DefaultCertificateRenewal,
 

--- a/internal/resources/frontproxy/certificates.go
+++ b/internal/resources/frontproxy/certificates.go
@@ -43,8 +43,8 @@ func ServerCertificateReconciler(frontProxy *operatorv1alpha1.FrontProxy, rootSh
 				SecretName: name,
 				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
 					Labels: map[string]string{
-						resources.RootShardLabel:  rootshard.Name,
-						resources.FrontProxyLabel: frontproxy.Name,
+						resources.RootShardLabel:  rootShard.Name,
+						resources.FrontProxyLabel: frontProxy.Name,
 					},
 				},
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
@@ -83,8 +83,8 @@ func AdminKubeconfigCertificateReconciler(frontProxy *operatorv1alpha1.FrontProx
 				SecretName: name,
 				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
 					Labels: map[string]string{
-						resources.RootShardLabel:  rootshard.Name,
-						resources.FrontProxyLabel: frontproxy.Name,
+						resources.RootShardLabel:  rootShard.Name,
+						resources.FrontProxyLabel: frontProxy.Name,
 					},
 				},
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
@@ -127,8 +127,8 @@ func KubeconfigCertificateReconciler(frontProxy *operatorv1alpha1.FrontProxy, ro
 				SecretName: name,
 				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
 					Labels: map[string]string{
-						resources.RootShardLabel:  rootshard.Name,
-						resources.FrontProxyLabel: frontproxy.Name,
+						resources.RootShardLabel:  rootShard.Name,
+						resources.FrontProxyLabel: frontProxy.Name,
 					},
 				},
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
@@ -171,8 +171,8 @@ func RequestHeaderCertificateReconciler(frontProxy *operatorv1alpha1.FrontProxy,
 				SecretName: name,
 				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
 					Labels: map[string]string{
-						resources.RootShardLabel:  rootshard.Name,
-						resources.FrontProxyLabel: frontproxy.Name,
+						resources.RootShardLabel:  rootShard.Name,
+						resources.FrontProxyLabel: frontProxy.Name,
 					},
 				},
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,

--- a/internal/resources/kubeconfig/certificate.go
+++ b/internal/resources/kubeconfig/certificate.go
@@ -21,6 +21,7 @@ import (
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
 	"github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -30,7 +31,12 @@ func ClientCertificateReconciler(kubeConfig *v1alpha1.Kubeconfig, issuerName str
 			cert.SetLabels(kubeConfig.Labels)
 			cert.Spec = certmanagerv1.CertificateSpec{
 				SecretName: kubeConfig.GetCertificateName(),
-				Duration:   &kubeConfig.Spec.Validity,
+				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
+					Labels: map[string]string{
+						resources.KubeconfigLabel: kubeConfig.Name,
+					},
+				},
+				Duration: &kubeConfig.Spec.Validity,
 
 				PrivateKey: &certmanagerv1.CertificatePrivateKey{
 					Algorithm: certmanagerv1.RSAKeyAlgorithm,

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -32,6 +32,13 @@ const (
 	appInstanceLabel  = "app.kubernetes.io/instance"
 	appManagedByLabel = "app.kubernetes.io/managed-by"
 	appComponentLabel = "app.kubernetes.io/component"
+
+	// RootShardLabel is placed on Secrets created for Certificates so that the operator can determine
+	// the grandparent object of a Secret when reconciling.
+	RootShardLabel  = "operator.kcp.io/rootshard"
+	ShardLabel      = "operator.kcp.io/shard"
+	FrontProxyLabel = "operator.kcp.io/front-proxy"
+	KubeconfigLabel = "operator.kcp.io/kubeconfig"
 )
 
 func GetImageSettings(imageSpec *operatorv1alpha1.ImageSpec) (string, []corev1.LocalObjectReference) {

--- a/internal/resources/rootshard/ca_certificates.go
+++ b/internal/resources/rootshard/ca_certificates.go
@@ -43,6 +43,11 @@ func RootCACertificateReconciler(rootShard *operatorv1alpha1.RootShard) reconcil
 				IsCA:       true,
 				CommonName: name,
 				SecretName: name,
+				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
+					Labels: map[string]string{
+						resources.RootShardLabel: rootShard.Name,
+					},
+				},
 				// Create CA certificate for ten years.
 				Duration:    &operatorv1alpha1.DefaultCADuration,
 				RenewBefore: &operatorv1alpha1.DefaultCARenewal,
@@ -74,6 +79,11 @@ func CACertificateReconciler(rootShard *operatorv1alpha1.RootShard, ca operatorv
 				IsCA:       true,
 				CommonName: name,
 				SecretName: name,
+				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
+					Labels: map[string]string{
+						resources.RootShardLabel: rootShard.Name,
+					},
+				},
 				// Create CA certificate for ten years.
 				Duration:    &operatorv1alpha1.DefaultCADuration,
 				RenewBefore: &operatorv1alpha1.DefaultCARenewal,

--- a/internal/resources/rootshard/certificates.go
+++ b/internal/resources/rootshard/certificates.go
@@ -32,7 +32,12 @@ func ServerCertificateReconciler(rootShard *operatorv1alpha1.RootShard) reconcil
 		return name, func(cert *certmanagerv1.Certificate) (*certmanagerv1.Certificate, error) {
 			cert.SetLabels(resources.GetRootShardResourceLabels(rootShard))
 			cert.Spec = certmanagerv1.CertificateSpec{
-				SecretName:  name,
+				SecretName: name,
+				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
+					Labels: map[string]string{
+						resources.RootShardLabel: rootShard.Name,
+					},
+				},
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
 				RenewBefore: &operatorv1alpha1.DefaultCertificateRenewal,
 
@@ -70,7 +75,12 @@ func VirtualWorkspacesCertificateReconciler(rootShard *operatorv1alpha1.RootShar
 		return name, func(cert *certmanagerv1.Certificate) (*certmanagerv1.Certificate, error) {
 			cert.SetLabels(resources.GetRootShardResourceLabels(rootShard))
 			cert.Spec = certmanagerv1.CertificateSpec{
-				SecretName:  name,
+				SecretName: name,
+				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
+					Labels: map[string]string{
+						resources.RootShardLabel: rootShard.Name,
+					},
+				},
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
 				RenewBefore: &operatorv1alpha1.DefaultCertificateRenewal,
 
@@ -106,8 +116,13 @@ func ServiceAccountCertificateReconciler(rootShard *operatorv1alpha1.RootShard) 
 		return name, func(cert *certmanagerv1.Certificate) (*certmanagerv1.Certificate, error) {
 			cert.SetLabels(resources.GetRootShardResourceLabels(rootShard))
 			cert.Spec = certmanagerv1.CertificateSpec{
-				CommonName:  name,
-				SecretName:  name,
+				CommonName: name,
+				SecretName: name,
+				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
+					Labels: map[string]string{
+						resources.RootShardLabel: rootShard.Name,
+					},
+				},
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
 				RenewBefore: &operatorv1alpha1.DefaultCertificateRenewal,
 


### PR DESCRIPTION
## Summary
This will add labels to the PodTemplate in each deployment, containing the current revisions of all mounted ConfigMaps/Secrets. This allows the Deployment to automatically be rolled out whenever these labels change. To this end the controllers now watch for changes in the Secrets.

Since the Secrets are usually owned by cert-manager and not directly created by the operator, the Owns() mechanism doesn't work. Instead we use https://cert-manager.io/docs/usage/certificate/#creating-certificate-resources to label the secrets and then simply deduce the grandparent object from those labels.

## Release Notes
```release-note
Add volume revision labels on Deployments to automate rollouts whenever a certificate changes.
```
