### PR TITLE
🌱 harmonize spelling of front-proxy, reduce public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ graph TB
 
     C --> D(kcp-etcd-client-ca):::ca
     C --> E(kcp-etcd-peer-ca):::ca
-    C --> F($rootshard-fp-client-ca):::ca
+    C --> F($rootshard-front-proxy-client-ca):::ca
     C --> G($rootshard-server-ca):::ca
     C --> H($rootshard-requestheaer-client-ca):::ca
     C --> I($rootshard-client-ca):::ca
@@ -51,7 +51,7 @@ graph TB
 
     D --> K([kcp-etcd-client-issuer]):::issuer
     E --> L([kcp-etcd-peer-issuer]):::issuer
-    F --> M([$rootshard-fp-client-ca]):::issuer
+    F --> M([$rootshard-front-proxy-client-ca]):::issuer
     G --> N([$rootshard-server-ca]):::issuer
     H --> O([$rootshard-requestheader-client-ca]):::issuer
     I --> P([$rootshard-client-ca]):::issuer

--- a/internal/controller/frontproxy_controller_test.go
+++ b/internal/controller/frontproxy_controller_test.go
@@ -42,7 +42,7 @@ var _ = Describe("FrontProxy Controller", func() {
 			Name:      resourceName,
 			Namespace: "default",
 		}
-		frontproxy := &operatorv1alpha1.FrontProxy{}
+		frontProxy := &operatorv1alpha1.FrontProxy{}
 		rootShard := &operatorv1alpha1.RootShard{}
 		rootShardNamespacedName := types.NamespacedName{
 			Name:      fmt.Sprintf("rootshard-%s", resourceName),
@@ -74,7 +74,7 @@ var _ = Describe("FrontProxy Controller", func() {
 			}
 
 			By("creating a FrontProxy object")
-			err = k8sClient.Get(ctx, typeNamespacedName, frontproxy)
+			err = k8sClient.Get(ctx, typeNamespacedName, frontProxy)
 			if err != nil && errors.IsNotFound(err) {
 				resource := &operatorv1alpha1.FrontProxy{
 					ObjectMeta: metav1.ObjectMeta{

--- a/internal/resources/frontproxy/certificates.go
+++ b/internal/resources/frontproxy/certificates.go
@@ -25,20 +25,20 @@ import (
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
-func ServerCertificateReconciler(frontproxy *operatorv1alpha1.FrontProxy, rootshard *operatorv1alpha1.RootShard) reconciling.NamedCertificateReconcilerFactory {
-	name := resources.GetFrontProxyCertificateName(rootshard, frontproxy, operatorv1alpha1.ServerCertificate)
+func ServerCertificateReconciler(frontProxy *operatorv1alpha1.FrontProxy, rootShard *operatorv1alpha1.RootShard) reconciling.NamedCertificateReconcilerFactory {
+	name := resources.GetFrontProxyCertificateName(rootShard, frontProxy, operatorv1alpha1.ServerCertificate)
 
 	dnsNames := []string{
-		rootshard.Spec.External.Hostname,
+		rootShard.Spec.External.Hostname,
 	}
 
-	if frontproxy.Spec.ExternalHostname != "" {
-		dnsNames = append(dnsNames, frontproxy.Spec.ExternalHostname)
+	if frontProxy.Spec.ExternalHostname != "" {
+		dnsNames = append(dnsNames, frontProxy.Spec.ExternalHostname)
 	}
 
 	return func() (string, reconciling.CertificateReconciler) {
 		return name, func(cert *certmanagerv1.Certificate) (*certmanagerv1.Certificate, error) {
-			cert.SetLabels(resources.GetFrontProxyResourceLabels(frontproxy))
+			cert.SetLabels(resources.GetFrontProxyResourceLabels(frontProxy))
 			cert.Spec = certmanagerv1.CertificateSpec{
 				SecretName:  name,
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
@@ -56,7 +56,7 @@ func ServerCertificateReconciler(frontproxy *operatorv1alpha1.FrontProxy, rootsh
 				DNSNames: dnsNames,
 
 				IssuerRef: certmanagermetav1.ObjectReference{
-					Name:  resources.GetRootShardCAName(rootshard, operatorv1alpha1.ServerCA),
+					Name:  resources.GetRootShardCAName(rootShard, operatorv1alpha1.ServerCA),
 					Kind:  "Issuer",
 					Group: "cert-manager.io",
 				},
@@ -67,12 +67,12 @@ func ServerCertificateReconciler(frontproxy *operatorv1alpha1.FrontProxy, rootsh
 	}
 }
 
-func AdminKubeconfigCertificateReconciler(frontproxy *operatorv1alpha1.FrontProxy, rootshard *operatorv1alpha1.RootShard) reconciling.NamedCertificateReconcilerFactory {
-	name := resources.GetFrontProxyCertificateName(rootshard, frontproxy, operatorv1alpha1.AdminKubeconfigClientCertificate)
+func AdminKubeconfigCertificateReconciler(frontProxy *operatorv1alpha1.FrontProxy, rootShard *operatorv1alpha1.RootShard) reconciling.NamedCertificateReconcilerFactory {
+	name := resources.GetFrontProxyCertificateName(rootShard, frontProxy, operatorv1alpha1.AdminKubeconfigClientCertificate)
 
 	return func() (string, reconciling.CertificateReconciler) {
 		return name, func(cert *certmanagerv1.Certificate) (*certmanagerv1.Certificate, error) {
-			cert.SetLabels(resources.GetFrontProxyResourceLabels(frontproxy))
+			cert.SetLabels(resources.GetFrontProxyResourceLabels(frontProxy))
 			cert.Spec = certmanagerv1.CertificateSpec{
 				SecretName:  name,
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
@@ -94,7 +94,7 @@ func AdminKubeconfigCertificateReconciler(frontproxy *operatorv1alpha1.FrontProx
 				},
 
 				IssuerRef: certmanagermetav1.ObjectReference{
-					Name:  resources.GetRootShardCAName(rootshard, operatorv1alpha1.FrontProxyClientCA),
+					Name:  resources.GetRootShardCAName(rootShard, operatorv1alpha1.FrontProxyClientCA),
 					Kind:  "Issuer",
 					Group: "cert-manager.io",
 				},
@@ -105,12 +105,12 @@ func AdminKubeconfigCertificateReconciler(frontproxy *operatorv1alpha1.FrontProx
 	}
 }
 
-func KubeconfigCertificateReconciler(frontproxy *operatorv1alpha1.FrontProxy, rootshard *operatorv1alpha1.RootShard) reconciling.NamedCertificateReconcilerFactory {
-	name := resources.GetFrontProxyCertificateName(rootshard, frontproxy, operatorv1alpha1.KubeconfigCertificate)
+func KubeconfigCertificateReconciler(frontProxy *operatorv1alpha1.FrontProxy, rootShard *operatorv1alpha1.RootShard) reconciling.NamedCertificateReconcilerFactory {
+	name := resources.GetFrontProxyCertificateName(rootShard, frontProxy, operatorv1alpha1.KubeconfigCertificate)
 
 	return func() (string, reconciling.CertificateReconciler) {
 		return name, func(cert *certmanagerv1.Certificate) (*certmanagerv1.Certificate, error) {
-			cert.SetLabels(resources.GetFrontProxyResourceLabels(frontproxy))
+			cert.SetLabels(resources.GetFrontProxyResourceLabels(frontProxy))
 			cert.Spec = certmanagerv1.CertificateSpec{
 				SecretName:  name,
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
@@ -132,7 +132,7 @@ func KubeconfigCertificateReconciler(frontproxy *operatorv1alpha1.FrontProxy, ro
 				},
 
 				IssuerRef: certmanagermetav1.ObjectReference{
-					Name:  resources.GetRootShardCAName(rootshard, operatorv1alpha1.ClientCA),
+					Name:  resources.GetRootShardCAName(rootShard, operatorv1alpha1.ClientCA),
 					Kind:  "Issuer",
 					Group: "cert-manager.io",
 				},
@@ -143,12 +143,12 @@ func KubeconfigCertificateReconciler(frontproxy *operatorv1alpha1.FrontProxy, ro
 	}
 }
 
-func RequestHeaderCertificateReconciler(frontproxy *operatorv1alpha1.FrontProxy, rootshard *operatorv1alpha1.RootShard) reconciling.NamedCertificateReconcilerFactory {
-	name := resources.GetFrontProxyRequestHeaderName(rootshard, frontproxy)
+func RequestHeaderCertificateReconciler(frontProxy *operatorv1alpha1.FrontProxy, rootShard *operatorv1alpha1.RootShard) reconciling.NamedCertificateReconcilerFactory {
+	name := resources.GetFrontProxyRequestHeaderName(rootShard, frontProxy)
 
 	return func() (string, reconciling.CertificateReconciler) {
 		return name, func(cert *certmanagerv1.Certificate) (*certmanagerv1.Certificate, error) {
-			cert.SetLabels(resources.GetFrontProxyResourceLabels(frontproxy))
+			cert.SetLabels(resources.GetFrontProxyResourceLabels(frontProxy))
 			cert.Spec = certmanagerv1.CertificateSpec{
 				SecretName:  name,
 				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
@@ -168,7 +168,7 @@ func RequestHeaderCertificateReconciler(frontproxy *operatorv1alpha1.FrontProxy,
 				},
 
 				IssuerRef: certmanagermetav1.ObjectReference{
-					Name:  resources.GetRootShardCAName(rootshard, operatorv1alpha1.RequestHeaderClientCA),
+					Name:  resources.GetRootShardCAName(rootShard, operatorv1alpha1.RequestHeaderClientCA),
 					Kind:  "Issuer",
 					Group: "cert-manager.io",
 				},

--- a/internal/resources/frontproxy/configmap.go
+++ b/internal/resources/frontproxy/configmap.go
@@ -26,15 +26,15 @@ import (
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
-func PathMappingConfigMapReconciler(frontproxy *operatorv1alpha1.FrontProxy, rootShard *operatorv1alpha1.RootShard) reconciling.NamedConfigMapReconcilerFactory {
-	name := resources.GetFrontProxyConfigName(frontproxy)
+func PathMappingConfigMapReconciler(frontProxy *operatorv1alpha1.FrontProxy, rootShard *operatorv1alpha1.RootShard) reconciling.NamedConfigMapReconcilerFactory {
+	name := resources.GetFrontProxyConfigName(frontProxy)
 
 	return func() (string, reconciling.ConfigMapReconciler) {
 		return name, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-			cm.SetLabels(resources.GetFrontProxyResourceLabels(frontproxy))
+			cm.SetLabels(resources.GetFrontProxyResourceLabels(frontProxy))
 
 			mappings := defaultPathMappings(rootShard)
-			mappings = append(mappings, frontproxy.Spec.AdditionalPathMappings...)
+			mappings = append(mappings, frontProxy.Spec.AdditionalPathMappings...)
 			d, err := yaml.Marshal(mappings)
 			if err != nil {
 				return nil, err

--- a/internal/resources/frontproxy/path.go
+++ b/internal/resources/frontproxy/path.go
@@ -17,6 +17,6 @@ limitations under the License.
 package frontproxy
 
 const (
-	FrontProxyBasepath = "/etc/kcp-front-proxy"
-	KcpBasepath        = "/etc/kcp"
+	frontProxyBasepath = "/etc/kcp-front-proxy"
+	kcpBasepath        = "/etc/kcp"
 )

--- a/internal/resources/frontproxy/secrets.go
+++ b/internal/resources/frontproxy/secrets.go
@@ -28,23 +28,23 @@ import (
 )
 
 const (
-	ClientCertPath        = FrontProxyBasepath + "/kubeconfig-client-cert"
-	ClientCertificatePath = ClientCertPath + "/tls.crt"
-	ClientKeyPath         = ClientCertPath + "/tls.key"
-	KubeconfigCAPath      = "/etc/kcp/tls/ca/tls.crt"
+	clientCertPath        = frontProxyBasepath + "/kubeconfig-client-cert"
+	clientCertificatePath = clientCertPath + "/tls.crt"
+	clientKeyPath         = clientCertPath + "/tls.key"
+	kubeconfigCAPath      = "/etc/kcp/tls/ca/tls.crt"
 )
 
-func DynamicKubeconfigSecretReconciler(frontproxy *operatorv1alpha1.FrontProxy, rootshard *operatorv1alpha1.RootShard) reconciling.NamedSecretReconcilerFactory {
+func DynamicKubeconfigSecretReconciler(frontProxy *operatorv1alpha1.FrontProxy, rootshard *operatorv1alpha1.RootShard) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
-		return resources.GetFrontProxyDynamicKubeconfigName(rootshard, frontproxy), func(obj *corev1.Secret) (*corev1.Secret, error) {
-			obj.SetLabels(resources.GetFrontProxyResourceLabels(frontproxy))
+		return resources.GetFrontProxyDynamicKubeconfigName(rootshard, frontProxy), func(obj *corev1.Secret) (*corev1.Secret, error) {
+			obj.SetLabels(resources.GetFrontProxyResourceLabels(frontProxy))
 
 			kubeconfig := clientcmdv1.Config{
 				Clusters: []clientcmdv1.NamedCluster{
 					{
 						Name: "system:admin",
 						Cluster: clientcmdv1.Cluster{
-							CertificateAuthority: KubeconfigCAPath,
+							CertificateAuthority: kubeconfigCAPath,
 							Server:               resources.GetRootShardBaseURL(rootshard),
 						},
 					},
@@ -63,8 +63,8 @@ func DynamicKubeconfigSecretReconciler(frontproxy *operatorv1alpha1.FrontProxy, 
 					{
 						Name: "admin",
 						AuthInfo: clientcmdv1.AuthInfo{
-							ClientCertificate: ClientCertificatePath,
-							ClientKey:         ClientKeyPath,
+							ClientCertificate: clientCertificatePath,
+							ClientKey:         clientKeyPath,
 						},
 					},
 				},

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -94,12 +94,12 @@ func GetRootShardCAName(r *operatorv1alpha1.RootShard, caName operatorv1alpha1.C
 	return fmt.Sprintf("%s-%s-ca", r.Name, caName)
 }
 
-func GetFrontProxyResourceLabels(fp *operatorv1alpha1.FrontProxy) map[string]string {
+func GetFrontProxyResourceLabels(f *operatorv1alpha1.FrontProxy) map[string]string {
 	return map[string]string{
 		appNameLabel:      "kcp",
-		appInstanceLabel:  fp.Name,
+		appInstanceLabel:  f.Name,
 		appManagedByLabel: "kcp-operator",
-		appComponentLabel: "frontproxy",
+		appComponentLabel: "front-proxy",
 	}
 }
 

--- a/sdk/apis/operator/v1alpha1/common.go
+++ b/sdk/apis/operator/v1alpha1/common.go
@@ -88,6 +88,6 @@ const (
 	ServerCA              CA = "server"
 	ServiceAccountCA      CA = "service-account"
 	ClientCA              CA = "client"
-	FrontProxyClientCA    CA = "fp-client"
+	FrontProxyClientCA    CA = "front-proxy-client"
 	RequestHeaderClientCA CA = "requestheader-client"
 )


### PR DESCRIPTION
## Summary
At various places did we use "fp" or "frontproxy" or "front-proxy" in our Kube identifiers, which irked me. This PR harmonizes them all to `front-proxy` (based on the binary name).

Additionally I changed some Go variables to un-shadow packages, plus I made some constants private that never needed to be public.

## Release Notes
```release-note
Consistently use `front-proxy` in Kubernetes object names
```
