### PR TITLE
:sparkles: Update default image tag to v0.26.1

### DIFF
--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	ImageRepository = "ghcr.io/kcp-dev/kcp"
-	ImageTag        = "v0.26.0"
+	ImageTag        = "v0.26.1"
 
 	appNameLabel      = "app.kubernetes.io/name"
 	appInstanceLabel  = "app.kubernetes.io/instance"


### PR DESCRIPTION
On-behalf-of: SAP <marvin.beckers@sap.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Just a small bump, we shouldn't ship 0.26.0 since it has a known security vulnerability.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Update default kcp image version to v0.26.1
```
