### PR TITLE
🌱 prevent constantly shadowing the client package with a client variable

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,12 @@ run:
   allow-parallel-runners: true
 
 issues:
+  max-same-issues: 0
+
   # don't skip warning about doc comments
   # don't exclude the default set of lint
   exclude-use-default: false
+
 linters:
   disable-all: true
   enable:
@@ -31,8 +34,6 @@ linters:
     - unused
 
 linters-settings:
-  max-same-issues: 0
-
   revive:
     rules:
       - name: comment-spacings
@@ -55,3 +56,6 @@ linters-settings:
         alias: apierrors
       - pkg: k8s.io/apimachinery/pkg/util/errors
         alias: kerrors
+      # Controller Runtime (otherwise this will usually lead to shadowing a local "client" variable)
+      - pkg: sigs.k8s.io/controller-runtime/pkg/client
+        alias: ctrlruntimeclient

--- a/internal/controller/cacheserver_controller.go
+++ b/internal/controller/cacheserver_controller.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
@@ -29,7 +29,7 @@ import (
 
 // CacheServerReconciler reconciles a CacheServer object
 type CacheServerReconciler struct {
-	client.Client
+	ctrlruntimeclient.Client
 	Scheme *runtime.Scheme
 }
 

--- a/internal/controller/kubeconfig_controller.go
+++ b/internal/controller/kubeconfig_controller.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
@@ -42,7 +42,7 @@ import (
 
 // KubeconfigReconciler reconciles a Kubeconfig object
 type KubeconfigReconciler struct {
-	client.Client
+	ctrlruntimeclient.Client
 	Scheme *runtime.Scheme
 }
 

--- a/internal/controller/rootshard_controller.go
+++ b/internal/controller/rootshard_controller.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
@@ -43,7 +43,7 @@ import (
 
 // RootShardReconciler reconciles a RootShard object
 type RootShardReconciler struct {
-	client.Client
+	ctrlruntimeclient.Client
 	Scheme *runtime.Scheme
 }
 
@@ -82,7 +82,7 @@ func (r *RootShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	var rootShard operatorv1alpha1.RootShard
 	if err := r.Client.Get(ctx, req.NamespacedName, &rootShard); err != nil {
-		if client.IgnoreNotFound(err) != nil {
+		if ctrlruntimeclient.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to find %s/%s: %w", req.Namespace, req.Name, err)
 		}
 
@@ -199,7 +199,7 @@ func (r *RootShardReconciler) reconcileStatus(ctx context.Context, oldRootShard 
 
 	// only patch the status if there are actual changes.
 	if !equality.Semantic.DeepEqual(oldRootShard.Status, rootShard.Status) {
-		if err := r.Client.Status().Patch(ctx, rootShard, client.MergeFrom(oldRootShard)); err != nil {
+		if err := r.Client.Status().Patch(ctx, rootShard, ctrlruntimeclient.MergeFrom(oldRootShard)); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -29,7 +29,7 @@ import (
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -41,7 +41,7 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var cfg *rest.Config
-var k8sClient client.Client
+var k8sClient ctrlruntimeclient.Client
 var testEnv *envtest.Environment
 var ctx context.Context
 var cancel context.CancelFunc
@@ -88,7 +88,7 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	k8sClient, err = ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
@@ -35,9 +35,9 @@ func deploymentReady(dep appsv1.Deployment) bool {
 	return dep.Status.UpdatedReplicas == dep.Status.ReadyReplicas && dep.Status.ReadyReplicas == ptr.Deref(dep.Spec.Replicas, 0)
 }
 
-func getDeploymentAvailableCondition(ctx context.Context, c client.Client, key types.NamespacedName) (metav1.Condition, error) {
+func getDeploymentAvailableCondition(ctx context.Context, client ctrlruntimeclient.Client, key types.NamespacedName) (metav1.Condition, error) {
 	var dep appsv1.Deployment
-	if err := c.Get(ctx, key, &dep); client.IgnoreNotFound(err) != nil {
+	if err := client.Get(ctx, key, &dep); ctrlruntimeclient.IgnoreNotFound(err) != nil {
 		return metav1.Condition{}, err
 	}
 
@@ -90,7 +90,7 @@ func updateCondition(conditions []metav1.Condition, newCondition metav1.Conditio
 	return conditions
 }
 
-func fetchRootShard(ctx context.Context, c client.Client, namespace string, ref *corev1.LocalObjectReference) (metav1.Condition, *operatorv1alpha1.RootShard) {
+func fetchRootShard(ctx context.Context, client ctrlruntimeclient.Client, namespace string, ref *corev1.LocalObjectReference) (metav1.Condition, *operatorv1alpha1.RootShard) {
 	if ref == nil {
 		return metav1.Condition{
 			Type:    string(operatorv1alpha1.ConditionTypeRootShard),
@@ -101,7 +101,7 @@ func fetchRootShard(ctx context.Context, c client.Client, namespace string, ref 
 	}
 
 	rootShard := &operatorv1alpha1.RootShard{}
-	if err := c.Get(ctx, types.NamespacedName{Name: ref.Name, Namespace: namespace}, rootShard); err != nil {
+	if err := client.Get(ctx, types.NamespacedName{Name: ref.Name, Namespace: namespace}, rootShard); err != nil {
 		return metav1.Condition{
 			Type:    string(operatorv1alpha1.ConditionTypeRootShard),
 			Status:  metav1.ConditionFalse,


### PR DESCRIPTION
## Summary
It's mega annoying to call a client variable `c` just to not shadow the `client` package in ctrlruntime.

## Release Notes
```release-note
NONE
```
