### PR TITLE
Bump golangci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,25 +1,14 @@
+version: "2"
 run:
-  timeout: 10m
   allow-parallel-runners: true
-
-issues:
-  max-same-issues: 0
-
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - copyloopvar
     - errcheck
     - ginkgolinter
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - importas
     - ineffassign
@@ -28,34 +17,47 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
-
-linters-settings:
-  revive:
-    rules:
-      - name: comment-spacings
-      - name: duplicated-imports
-        severity: warning
-  importas:
-    no-unaliased: true
-    alias:
-      # kcp operator
-      - pkg: github.com/kcp-dev/kcp-operator/sdk/apis/(\w+)/(v[\w\d]+)
-        alias: $1$2
-      # Kubernetes
-      - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
-        alias: $1$2
-      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-        alias: metav1
-      - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
-        alias: apiextensionsv1
-      - pkg: k8s.io/apimachinery/pkg/api/errors
-        alias: apierrors
-      - pkg: k8s.io/apimachinery/pkg/util/errors
-        alias: kerrors
-      # Controller Runtime (otherwise this will usually lead to shadowing a local "client" variable)
-      - pkg: sigs.k8s.io/controller-runtime/pkg/client
-        alias: ctrlruntimeclient
+  settings:
+    importas:
+      alias:
+        - pkg: github.com/kcp-dev/kcp-operator/sdk/apis/(\w+)/(v[\w\d]+)
+          alias: $1$2
+        - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
+          alias: $1$2
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+          alias: apiextensionsv1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: k8s.io/apimachinery/pkg/util/errors
+          alias: kerrors
+        - pkg: sigs.k8s.io/controller-runtime/pkg/client
+          alias: ctrlruntimeclient
+      no-unaliased: true
+    revive:
+      rules:
+        - name: comment-spacings
+        - name: duplicated-imports
+          severity: warning
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ KUBECTL_VERSION ?= v1.32.0
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.16.1
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= 1.63.4
+GOLANGCI_LINT_VERSION ?= 2.1.6
 
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/kcp-dev/kcp-operator
@@ -72,11 +72,11 @@ test-e2e:
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter.
-	$(GOLANGCI_LINT) run
+	$(GOLANGCI_LINT) run --timeout 10m
 
 .PHONY: lint-fix
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes.
-	$(GOLANGCI_LINT) run --fix
+	$(GOLANGCI_LINT) run --timeout 10m --fix
 
 .PHONY: modules
 modules: ## Run go mod tidy to ensure modules are up to date.

--- a/internal/controller/frontproxy_controller.go
+++ b/internal/controller/frontproxy_controller.go
@@ -94,7 +94,7 @@ func (r *FrontProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	logger.V(4).Info("Reconciling")
 
 	var frontProxy operatorv1alpha1.FrontProxy
-	if err := r.Client.Get(ctx, req.NamespacedName, &frontProxy); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &frontProxy); err != nil {
 		if ctrlruntimeclient.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get FrontProxy object: %w", err)
 		}
@@ -204,7 +204,7 @@ func (r *FrontProxyReconciler) reconcileStatus(ctx context.Context, oldFrontProx
 
 	// only patch the status if there are actual changes.
 	if !equality.Semantic.DeepEqual(oldFrontProxy.Status, frontProxy.Status) {
-		if err := r.Client.Status().Patch(ctx, frontProxy, ctrlruntimeclient.MergeFrom(oldFrontProxy)); err != nil {
+		if err := r.Status().Patch(ctx, frontProxy, ctrlruntimeclient.MergeFrom(oldFrontProxy)); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/internal/controller/kubeconfig_controller.go
+++ b/internal/controller/kubeconfig_controller.go
@@ -69,7 +69,7 @@ func (r *KubeconfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	logger.V(4).Info("Reconciling")
 
 	var kc operatorv1alpha1.Kubeconfig
-	if err := r.Client.Get(ctx, req.NamespacedName, &kc); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &kc); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -80,7 +80,7 @@ func (r *KubeconfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	switch {
 	case kc.Spec.Target.RootShardRef != nil:
 		var rootShard operatorv1alpha1.RootShard
-		if err := r.Client.Get(ctx, types.NamespacedName{Name: kc.Spec.Target.RootShardRef.Name, Namespace: req.Namespace}, &rootShard); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Name: kc.Spec.Target.RootShardRef.Name, Namespace: req.Namespace}, &rootShard); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get RootShard: %w", err)
 		}
 
@@ -91,7 +91,7 @@ func (r *KubeconfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	case kc.Spec.Target.ShardRef != nil:
 		var shard operatorv1alpha1.Shard
-		if err := r.Client.Get(ctx, types.NamespacedName{Name: kc.Spec.Target.ShardRef.Name, Namespace: req.Namespace}, &shard); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Name: kc.Spec.Target.ShardRef.Name, Namespace: req.Namespace}, &shard); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Shard: %w", err)
 		}
 
@@ -100,7 +100,7 @@ func (r *KubeconfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, errors.New("the Shard does not reference a (valid) RootShard")
 		}
 		var rootShard operatorv1alpha1.RootShard
-		if err := r.Client.Get(ctx, types.NamespacedName{Name: ref.Name, Namespace: req.Namespace}, &rootShard); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Name: ref.Name, Namespace: req.Namespace}, &rootShard); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get RootShard: %w", err)
 		}
 
@@ -112,7 +112,7 @@ func (r *KubeconfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	case kc.Spec.Target.FrontProxyRef != nil:
 		var frontProxy operatorv1alpha1.FrontProxy
-		if err := r.Client.Get(ctx, types.NamespacedName{Name: kc.Spec.Target.FrontProxyRef.Name, Namespace: req.Namespace}, &frontProxy); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Name: kc.Spec.Target.FrontProxyRef.Name, Namespace: req.Namespace}, &frontProxy); err != nil {
 			return ctrl.Result{}, fmt.Errorf("referenced FrontProxy '%s' does not exist", kc.Spec.Target.FrontProxyRef.Name)
 		}
 
@@ -121,7 +121,7 @@ func (r *KubeconfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, errors.New("the FrontProxy does not reference a (valid) RootShard")
 		}
 		var rootShard operatorv1alpha1.RootShard
-		if err := r.Client.Get(ctx, types.NamespacedName{Name: frontProxy.Spec.RootShard.Reference.Name, Namespace: req.Namespace}, &rootShard); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Name: frontProxy.Spec.RootShard.Reference.Name, Namespace: req.Namespace}, &rootShard); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get RootShard: %w", err)
 		}
 
@@ -174,7 +174,7 @@ func (r *KubeconfigReconciler) getCertificateSecret(ctx context.Context, name, n
 	logger := log.FromContext(ctx).WithValues("certificate", name)
 
 	certificate := &certmanagerv1.Certificate{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, certificate); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, certificate); err != nil {
 		// Because of how the reconciling framework works, this should never happen.
 		logger.V(6).Info("Certificate does not exist yet, trying later ...")
 		return nil, nil
@@ -194,7 +194,7 @@ func (r *KubeconfigReconciler) getCertificateSecret(ctx context.Context, name, n
 	}
 
 	secret := &corev1.Secret{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: certificate.Spec.SecretName, Namespace: certificate.Namespace}, secret); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: certificate.Spec.SecretName, Namespace: certificate.Namespace}, secret); err != nil {
 		return nil, err
 	}
 

--- a/internal/controller/rootshard_controller.go
+++ b/internal/controller/rootshard_controller.go
@@ -81,7 +81,7 @@ func (r *RootShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	logger.V(4).Info("Reconciling")
 
 	var rootShard operatorv1alpha1.RootShard
-	if err := r.Client.Get(ctx, req.NamespacedName, &rootShard); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &rootShard); err != nil {
 		if ctrlruntimeclient.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to find %s/%s: %w", req.Namespace, req.Name, err)
 		}
@@ -199,7 +199,7 @@ func (r *RootShardReconciler) reconcileStatus(ctx context.Context, oldRootShard 
 
 	// only patch the status if there are actual changes.
 	if !equality.Semantic.DeepEqual(oldRootShard.Status, rootShard.Status) {
-		if err := r.Client.Status().Patch(ctx, rootShard, ctrlruntimeclient.MergeFrom(oldRootShard)); err != nil {
+		if err := r.Status().Patch(ctx, rootShard, ctrlruntimeclient.MergeFrom(oldRootShard)); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/internal/controller/shard_controller.go
+++ b/internal/controller/shard_controller.go
@@ -93,7 +93,7 @@ func (r *ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res 
 	logger.V(4).Info("Reconciling Shard object")
 
 	var s operatorv1alpha1.Shard
-	if err := r.Client.Get(ctx, req.NamespacedName, &s); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &s); err != nil {
 		if ctrlruntimeclient.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get shard: %w", err)
 		}

--- a/internal/resources/frontproxy/deployment.go
+++ b/internal/resources/frontproxy/deployment.go
@@ -39,7 +39,7 @@ func DeploymentReconciler(frontProxy *operatorv1alpha1.FrontProxy, rootShard *op
 			dep.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: resources.GetFrontProxyResourceLabels(frontProxy),
 			}
-			dep.Spec.Template.ObjectMeta.SetLabels(resources.GetFrontProxyResourceLabels(frontProxy))
+			dep.Spec.Template.SetLabels(resources.GetFrontProxyResourceLabels(frontProxy))
 
 			image, _ := resources.GetImageSettings(frontProxy.Spec.Image)
 			args := getArgs(&frontProxy.Spec)

--- a/internal/resources/rootshard/deployment.go
+++ b/internal/resources/rootshard/deployment.go
@@ -70,7 +70,7 @@ func DeploymentReconciler(rootShard *operatorv1alpha1.RootShard) reconciling.Nam
 			dep.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: labels,
 			}
-			dep.Spec.Template.ObjectMeta.SetLabels(labels)
+			dep.Spec.Template.SetLabels(labels)
 
 			secretMounts := []utils.SecretMount{{
 				VolumeName: "kcp-ca",

--- a/internal/resources/shard/deployment.go
+++ b/internal/resources/shard/deployment.go
@@ -69,7 +69,7 @@ func DeploymentReconciler(shard *operatorv1alpha1.Shard, rootShard *operatorv1al
 			dep.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: labels,
 			}
-			dep.Spec.Template.ObjectMeta.SetLabels(labels)
+			dep.Spec.Template.SetLabels(labels)
 
 			secretMounts := []utils.SecretMount{{
 				VolumeName: "kcp-ca",

--- a/internal/resources/utils/shard.go
+++ b/internal/resources/utils/shard.go
@@ -31,6 +31,7 @@ import (
 
 func ApplyCommonShardConfig(deployment *appsv1.Deployment, spec *operatorv1alpha1.CommonShardSpec) (*appsv1.Deployment, error) {
 	if len(deployment.Spec.Template.Spec.Containers) == 0 {
+		//nolint:staticcheck // allow capital letter in error message
 		return deployment, errors.New("Deployment does not contain any containers")
 	}
 


### PR DESCRIPTION
## Summary
This bumps golangci-lint and fixes that running "make lint" would not re-download the requested version.

## What Type of PR Is This?
/kind cleanup

## Release Notes
```release-note
Update golangci-lint to 2.1.x
```
