### PR TITLE
Mount correct server certificate into front-proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.16.1
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= 2.1.6
+PROTOKOL_VERSION ?= 0.7.2
 
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/kcp-dev/kcp-operator
@@ -151,6 +152,7 @@ KUBECTL ?= $(TOOLS_DIR)/kubectl
 KUSTOMIZE ?= $(TOOLS_DIR)/kustomize
 ENVTEST ?= $(TOOLS_DIR)/setup-envtest
 GOLANGCI_LINT = $(TOOLS_DIR)/golangci-lint
+PROTOKOL = $(TOOLS_DIR)/protokol
 RECONCILER_GEN := $(TOOLS_DIR)/reconciler-gen
 OPENSHIFT_GOIMPORTS := $(TOOLS_DIR)/openshift-goimports
 
@@ -181,6 +183,13 @@ golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 .PHONY: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT):
 	@hack/download-tool.sh https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-$(shell go env GOOS)-$(shell go env GOARCH).tar.gz golangci-lint $(GOLANGCI_LINT_VERSION)
+
+.PHONY: protokol
+protokol: $(PROTOKOL) ## Download protokol locally if necessary.
+
+.PHONY: $(PROTOKOL)
+$(PROTOKOL):
+	@hack/download-tool.sh https://codeberg.org/xrstf/protokol/releases/download/v${PROTOKOL_VERSION}/protokol_${PROTOKOL_VERSION}_$(shell go env GOOS)_$(shell go env GOARCH).tar.gz protokol $(PROTOKOL_VERSION)
 
 .PHONY: reconciler-gen
 reconciler-gen: $(RECONCILER_GEN) ## Download reconciler-gen locally if necessary.

--- a/hack/ci/run-e2e-tests.sh
+++ b/hack/ci/run-e2e-tests.sh
@@ -36,6 +36,10 @@ echo "Creating kind cluster $KIND_CLUSTER_NAME…"
 kind create cluster --name "$KIND_CLUSTER_NAME"
 chmod 600 "$KUBECONFIG"
 
+# store logs as artifacts
+make protokol
+_tools/protokol --output "$ARTIFACTS/logs" --namespace 'kcp-*' --namespace 'e2e-*' >/dev/null 2>&1 &
+
 # load the operator image into the kind cluster
 image="ghcr.io/kcp-dev/kcp-operator:$IMAGE_TAG"
 archive=operator.tar

--- a/internal/resources/frontproxy/certificates.go
+++ b/internal/resources/frontproxy/certificates.go
@@ -34,6 +34,7 @@ func ServerCertificateReconciler(frontProxy *operatorv1alpha1.FrontProxy, rootSh
 
 	dnsNames := []string{
 		rootShard.Spec.External.Hostname,
+		resources.GetFrontProxyServiceName(frontProxy),
 	}
 
 	if frontProxy.Spec.ExternalHostname != "" {

--- a/internal/resources/frontproxy/deployment.go
+++ b/internal/resources/frontproxy/deployment.go
@@ -143,15 +143,15 @@ func DeploymentReconciler(frontProxy *operatorv1alpha1.FrontProxy, rootShard *op
 
 			// front-proxy server cert
 			volumes = append(volumes, corev1.Volume{
-				Name: resources.GetRootShardCertificateName(rootShard, operatorv1alpha1.ServerCertificate),
+				Name: resources.GetFrontProxyCertificateName(rootShard, frontProxy, operatorv1alpha1.ServerCertificate),
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: resources.GetRootShardCertificateName(rootShard, operatorv1alpha1.ServerCertificate),
+						SecretName: resources.GetFrontProxyCertificateName(rootShard, frontProxy, operatorv1alpha1.ServerCertificate),
 					},
 				},
 			})
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{
-				Name:      resources.GetRootShardCertificateName(rootShard, operatorv1alpha1.ServerCertificate),
+				Name:      resources.GetFrontProxyCertificateName(rootShard, frontProxy, operatorv1alpha1.ServerCertificate),
 				ReadOnly:  true,
 				MountPath: frontProxyBasepath + "/tls",
 			})

--- a/internal/resources/rootshard/certificates.go
+++ b/internal/resources/rootshard/certificates.go
@@ -55,7 +55,6 @@ func ServerCertificateReconciler(rootShard *operatorv1alpha1.RootShard) reconcil
 				},
 
 				DNSNames: []string{
-					"localhost",
 					resources.GetRootShardBaseHost(rootShard),
 					rootShard.Spec.External.Hostname,
 				},

--- a/test/e2e/frontproxies/frontproxies_test.go
+++ b/test/e2e/frontproxies/frontproxies_test.go
@@ -42,24 +42,23 @@ func TestCreateFrontProxy(t *testing.T) {
 
 	client := utils.GetKubeClient(t)
 	ctx := context.Background()
-	namespace := "create-frontproxy"
 
-	utils.CreateSelfDestructingNamespace(t, ctx, client, namespace)
+	namespace := utils.CreateSelfDestructingNamespace(t, ctx, client, "create-frontproxy")
 
 	externalHostname := "front-proxy-front-proxy.svc.cluster.local"
 
 	// deploy rootshard
-	rootShard := utils.DeployRootShard(ctx, t, client, namespace, externalHostname)
+	rootShard := utils.DeployRootShard(ctx, t, client, namespace.Name, externalHostname)
 
 	// deploy front-proxy
-	frontProxy := utils.DeployFrontProxy(ctx, t, client, namespace, rootShard.Name, externalHostname)
+	frontProxy := utils.DeployFrontProxy(ctx, t, client, namespace.Name, rootShard.Name, externalHostname)
 
 	// create front-proxy kubeconfig
 	configSecretName := "kubeconfig-front-proxy-e2e"
 
 	fpConfig := operatorv1alpha1.Kubeconfig{}
 	fpConfig.Name = "front-proxy"
-	fpConfig.Namespace = namespace
+	fpConfig.Namespace = namespace.Name
 	fpConfig.Spec = operatorv1alpha1.KubeconfigSpec{
 		Target: operatorv1alpha1.KubeconfigTarget{
 			FrontProxyRef: &corev1.LocalObjectReference{
@@ -82,7 +81,7 @@ func TestCreateFrontProxy(t *testing.T) {
 
 	// verify that we can use frontproxy kubeconfig to access rootshard workspaces
 	t.Log("Connecting to FrontProxy…")
-	kcpClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace, fpConfig.Name)
+	kcpClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace.Name, fpConfig.Name)
 	// proof of life: list something every logicalcluster in kcp has
 	t.Log("Should be able to list Secrets.")
 	secrets := &corev1.SecretList{}

--- a/test/e2e/rootshards/rootshards_test.go
+++ b/test/e2e/rootshards/rootshards_test.go
@@ -39,16 +39,15 @@ func TestCreateRootShard(t *testing.T) {
 
 	client := utils.GetKubeClient(t)
 	ctx := context.Background()
-	namespace := "create-rootshard"
 
-	utils.CreateSelfDestructingNamespace(t, ctx, client, namespace)
-	rootShard := utils.DeployRootShard(ctx, t, client, namespace, "example.localhost")
+	namespace := utils.CreateSelfDestructingNamespace(t, ctx, client, "create-rootshard")
+	rootShard := utils.DeployRootShard(ctx, t, client, namespace.Name, "example.localhost")
 
 	configSecretName := "kubeconfig"
 
 	rsConfig := operatorv1alpha1.Kubeconfig{}
 	rsConfig.Name = "test"
-	rsConfig.Namespace = namespace
+	rsConfig.Namespace = namespace.Name
 
 	rsConfig.Spec = operatorv1alpha1.KubeconfigSpec{
 		Target: operatorv1alpha1.KubeconfigTarget{
@@ -71,7 +70,7 @@ func TestCreateRootShard(t *testing.T) {
 	utils.WaitForObject(t, ctx, client, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
 
 	t.Log("Connecting to RootShard…")
-	kcpClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace, rsConfig.Name)
+	kcpClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace.Name, rsConfig.Name)
 
 	// proof of life: list something every logicalcluster in kcp has
 	t.Log("Should be able to list Secrets.")

--- a/test/utils/deploy.go
+++ b/test/utils/deploy.go
@@ -132,6 +132,13 @@ func DeployRootShard(ctx context.Context, t *testing.T, client ctrlruntimeclient
 			Etcd: operatorv1alpha1.EtcdConfig{
 				Endpoints: []string{etcd},
 			},
+			CertificateTemplates: operatorv1alpha1.CertificateTemplateMap{
+				string(operatorv1alpha1.ServerCertificate): operatorv1alpha1.CertificateTemplate{
+					Spec: &operatorv1alpha1.CertificateSpecTemplate{
+						DNSNames: []string{"localhost"},
+					},
+				},
+			},
 		},
 	}
 
@@ -169,10 +176,16 @@ func DeployFrontProxy(ctx context.Context, t *testing.T, client ctrlruntimeclien
 				Name: rootShardName,
 			},
 		},
-		ExternalHostname: externalHostname,
 		Auth: &operatorv1alpha1.AuthSpec{
 			// we need to remove the default system:masters group in order to do our testing
 			DropGroups: []string{""},
+		},
+		CertificateTemplates: operatorv1alpha1.CertificateTemplateMap{
+			string(operatorv1alpha1.ServerCertificate): operatorv1alpha1.CertificateTemplate{
+				Spec: &operatorv1alpha1.CertificateSpecTemplate{
+					DNSNames: []string{"localhost"},
+				},
+			},
 		},
 	}
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -77,11 +77,11 @@ func GetKubeClient(t *testing.T) ctrlruntimeclient.Client {
 	return c
 }
 
-func CreateSelfDestructingNamespace(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, name string) {
+func CreateSelfDestructingNamespace(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, name string) *corev1.Namespace {
 	t.Helper()
 
 	ns := corev1.Namespace{}
-	ns.Name = name
+	ns.Name = fmt.Sprintf("e2e-%s", name)
 
 	t.Logf("Creating namespace %s…", name)
 	if err := client.Create(ctx, &ns); err != nil {
@@ -94,6 +94,8 @@ func CreateSelfDestructingNamespace(t *testing.T, ctx context.Context, client ct
 			t.Fatal(err)
 		}
 	})
+
+	return &ns
 }
 
 func SelfDestuctingPortForward(


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Looks like we have been mounting the wrong TLS server certificate for the front-proxy all along. Weirdly, we didn't catch this, because the cert includes both `localhost` and the external name, but it's not subjected to `spec.certificateTemplates` overrides placed in a `FrontProxy` object, which is what made me realize this. The server certificate should also include the front-proxy service name, I suppose.

Also remove `localhost` by default from the shard certificate, it can be added via `spec.certificateTemplates` now.

## What Type of PR Is This?

/kind bug

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Mount correct server certificate into front-proxy, stop embedding `localhost` in root shard server certificate
```
