### PR TITLE
disable admin battery in kcp

### DIFF
--- a/internal/resources/rootshard/deployment.go
+++ b/internal/resources/rootshard/deployment.go
@@ -18,6 +18,7 @@ package rootshard
 
 import (
 	"fmt"
+	"strings"
 
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -172,6 +173,7 @@ func getArgs(rootShard *operatorv1alpha1.RootShard) []string {
 		fmt.Sprintf("--shard-external-url=https://%s:%d", rootShard.Spec.External.Hostname, rootShard.Spec.External.Port),
 		fmt.Sprintf("--logical-cluster-admin-kubeconfig=%s/kubeconfig", getKubeconfigMountPath(operatorv1alpha1.LogicalClusterAdminCertificate)),
 		fmt.Sprintf("--external-logical-cluster-admin-kubeconfig=%s/kubeconfig", getKubeconfigMountPath(operatorv1alpha1.ExternalLogicalClusterAdminCertificate)),
+		fmt.Sprintf("--batteries-included=%s", strings.Join(utils.GetRootShardBatteries(rootShard), ",")),
 		"--root-directory=",
 		"--enable-leader-election=true",
 		"--logging-format=json",

--- a/internal/resources/shard/deployment.go
+++ b/internal/resources/shard/deployment.go
@@ -18,6 +18,7 @@ package shard
 
 import (
 	"fmt"
+	"strings"
 
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -172,6 +173,7 @@ func getArgs(shard *operatorv1alpha1.Shard, rootShard *operatorv1alpha1.RootShar
 		fmt.Sprintf("--shard-external-url=https://%s:%d", rootShard.Spec.External.Hostname, rootShard.Spec.External.Port),
 		fmt.Sprintf("--root-shard-kubeconfig-file=%s/kubeconfig", getKubeconfigMountPath(operatorv1alpha1.ClientCertificate)),
 		fmt.Sprintf("--cache-kubeconfig=%s/kubeconfig", getKubeconfigMountPath(operatorv1alpha1.ClientCertificate)),
+		fmt.Sprintf("--batteries-included=%s", strings.Join(utils.GetShardBatteries(shard), ",")),
 		"--root-directory=",
 		"--enable-leader-election=true",
 		"--logging-format=json",

--- a/internal/resources/utils/shard.go
+++ b/internal/resources/utils/shard.go
@@ -28,6 +28,18 @@ import (
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
+func getCommonShardBatteries() []string {
+	return []string{"workspace-types"}
+}
+
+func GetShardBatteries(shard *operatorv1alpha1.Shard) []string {
+	return getCommonShardBatteries()
+}
+
+func GetRootShardBatteries(rootShard *operatorv1alpha1.RootShard) []string {
+	return getCommonShardBatteries()
+}
+
 func ApplyCommonShardConfig(deployment *appsv1.Deployment, spec *operatorv1alpha1.CommonShardSpec) *appsv1.Deployment {
 	if len(deployment.Spec.Template.Spec.Containers) == 0 {
 		panic("Deployment does not contain any containers.")


### PR DESCRIPTION
## Summary
Since https://github.com/kcp-dev/kcp/pull/3434, the kcp container images do not have a volume anymore and their working directory is no longer `/data` by default. This has made it so that the `admin` battery will now fail to create the `.admin-token-store` file because the container's filesystem is readonly.

This will affect kcp 0.28+.

This PR makes it so that we for now just disable the battery. We do not need it anyway. In the future we might make the batteries configurable, but then we need to make sure nobody enables the admin battery without us also making some scratchpad volume available to the kcp pods.

## What Type of PR Is This?
/kind bug

## Release Notes
```release-note
The `admin` battery is disabled now to improve compatibility with kcp 0.28's readonly container filesystem.
```
