### PR TITLE
update to Go 1.24.4

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
+        - image: ghcr.io/kcp-dev/infra/build:1.24.4-1
           command:
             - make
             - verify
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
+        - image: ghcr.io/kcp-dev/infra/build:1.24.4-1
           command:
             - make
             - lint
@@ -63,7 +63,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
+        - image: ghcr.io/kcp-dev/infra/build:1.24.4-1
           command:
             - make
             - test
@@ -83,7 +83,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
+        - image: ghcr.io/kcp-dev/infra/build:1.24.4-1
           command:
             - hack/ci/run-e2e-tests.sh
           resources:
@@ -103,7 +103,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
+        - image: ghcr.io/kcp-dev/infra/build:1.24.4-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.23.9 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.4 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
The operator doesn't really depend on kcp's kube lifecycle and so I think we can safely upgrade to Go 1.24.

## What Type of PR Is This?
/kind feature

## Release Notes
```release-note
Update to Go 1.24.4
```
