### PR TITLE
Create base/default contexts in kubeconfigs and extend samples

### DIFF
--- a/config/samples/v1alpha1_frontproxy.yaml
+++ b/config/samples/v1alpha1_frontproxy.yaml
@@ -6,12 +6,6 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: frontproxy-sample
 spec:
-  image:
-    tag: eb60348a
-  auth:
-    # don't drop requests from administrative groups.
-    # this shouldn't be enabled in production, but makes testing easier.
-    dropGroups: [""]
   rootShard:
     ref:
       name: shard-sample

--- a/config/samples/v1alpha1_frontproxy.yaml
+++ b/config/samples/v1alpha1_frontproxy.yaml
@@ -6,7 +6,27 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: frontproxy-sample
 spec:
+  image:
+    tag: eb60348a
+  auth:
+    # don't drop requests from administrative groups.
+    # this shouldn't be enabled in production, but makes testing easier.
+    dropGroups: [""]
   rootShard:
     ref:
       name: shard-sample
-  externalHostname: kcp.example.com
+  serviceTemplate:
+    spec:
+      # hard code a specific cluster IP, e.g. for a kind setup.
+      clusterIP: 10.96.100.100
+  certificateTemplates:
+    server:
+      spec:
+        dnsNames:
+          # add localhost to the certificate.
+          - localhost
+        ipAddresses:
+          # add localhost IPs to the server certificate.
+          # this allows easy port-forward access.
+          - 127.0.0.1
+          - 127.0.0.2

--- a/config/samples/v1alpha1_kubeconfig_frontproxy.yaml
+++ b/config/samples/v1alpha1_kubeconfig_frontproxy.yaml
@@ -1,0 +1,19 @@
+apiVersion: operator.kcp.io/v1alpha1
+kind: Kubeconfig
+metadata:
+  labels:
+    app.kubernetes.io/name: kcp-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: kubeconfig-kcp-admin
+spec:
+  username: kcp-admin
+  groups:
+    - system:kcp:admin
+  validity: 8766h
+  secretRef:
+    name: sample-kubeconfig
+  target:
+    frontProxyRef:
+      name: frontproxy-sample
+    # rootShardRef:
+    #   name: shard-sample

--- a/config/samples/v1alpha1_kubeconfig_rootshard.yaml
+++ b/config/samples/v1alpha1_kubeconfig_rootshard.yaml
@@ -4,16 +4,14 @@ metadata:
   labels:
     app.kubernetes.io/name: kcp-operator
     app.kubernetes.io/managed-by: kustomize
-  name: kubeconfig-sample
+  name: kubeconfig-shard-root-admin
 spec:
-  username: user@kcp.io
+  username: shard-root-admin
   groups:
-    - kcp-users
+    - system:kcp:admin
   validity: 8766h
   secretRef:
-    name: sample-kubeconfig
+    name: kubeconfig-shard-root-admin
   target:
-    frontProxyRef:
-      name: frontproxy-sample
-    # rootShardRef:
-    #   name: shard-sample
+    rootShardRef:
+      name: shard-sample

--- a/config/samples/v1alpha1_kubeconfig_shard.yaml
+++ b/config/samples/v1alpha1_kubeconfig_shard.yaml
@@ -1,0 +1,17 @@
+apiVersion: operator.kcp.io/v1alpha1
+kind: Kubeconfig
+metadata:
+  labels:
+    app.kubernetes.io/name: kcp-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: kubeconfig-shard-secondary-admin
+spec:
+  username: shard-root-admin
+  groups:
+    - system:kcp:admin
+  validity: 8766h
+  secretRef:
+    name: kubeconfig-shard-secondary-admin
+  target:
+    shardRef:
+      name: secondary-shard

--- a/config/samples/v1alpha1_rootshard.yaml
+++ b/config/samples/v1alpha1_rootshard.yaml
@@ -6,8 +6,6 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: shard-sample
 spec:
-  image:
-    tag: eb60348a
   external:
     hostname: example.operator.kcp.io
     port: 6443

--- a/config/samples/v1alpha1_rootshard.yaml
+++ b/config/samples/v1alpha1_rootshard.yaml
@@ -6,6 +6,8 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: shard-sample
 spec:
+  image:
+    tag: eb60348a
   external:
     hostname: example.operator.kcp.io
     port: 6443
@@ -20,3 +22,12 @@ spec:
   etcd:
     endpoints:
       - http://etcd.default.svc.cluster.local:2379
+  deploymentTemplate:
+    spec:
+      template:
+        spec:
+          hostAliases:
+            # add a hardcoded DNS override to the same IP as in v1alpha1_frontproxy.yaml.
+            - ip: "10.96.100.100"
+              hostnames:
+                - "example.operator.kcp.io"

--- a/config/samples/v1alpha1_shard.yaml
+++ b/config/samples/v1alpha1_shard.yaml
@@ -6,8 +6,6 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: secondary-shard
 spec:
-  image:
-    tag: eb60348a
   etcd:
     endpoints:
       - http://etcd-shard.default.svc.cluster.local:2379

--- a/config/samples/v1alpha1_shard.yaml
+++ b/config/samples/v1alpha1_shard.yaml
@@ -4,6 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/name: kcp-operator
     app.kubernetes.io/managed-by: kustomize
-  name: shard-sample
+  name: secondary-shard
 spec:
-  # TODO(user): Add fields here
+  image:
+    tag: eb60348a
+  etcd:
+    endpoints:
+      - http://etcd-shard.default.svc.cluster.local:2379
+  rootShard:
+    ref:
+      name: shard-sample

--- a/internal/controller/kubeconfig_controller.go
+++ b/internal/controller/kubeconfig_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -73,25 +72,25 @@ func (r *KubeconfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	rootShard := &operatorv1alpha1.RootShard{}
+	shard := &operatorv1alpha1.Shard{}
+
 	var (
-		clientCertIssuer, serverCA, serverURL, serverName string
+		clientCertIssuer string
+		serverCA         string
 	)
 
 	switch {
 	case kc.Spec.Target.RootShardRef != nil:
-		var rootShard operatorv1alpha1.RootShard
-		if err := r.Get(ctx, types.NamespacedName{Name: kc.Spec.Target.RootShardRef.Name, Namespace: req.Namespace}, &rootShard); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Name: kc.Spec.Target.RootShardRef.Name, Namespace: req.Namespace}, rootShard); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get RootShard: %w", err)
 		}
 
-		clientCertIssuer = resources.GetRootShardCAName(&rootShard, operatorv1alpha1.ClientCA)
-		serverCA = resources.GetRootShardCAName(&rootShard, operatorv1alpha1.ServerCA)
-		serverURL = resources.GetRootShardBaseURL(&rootShard)
-		serverName = rootShard.Name
+		clientCertIssuer = resources.GetRootShardCAName(rootShard, operatorv1alpha1.ClientCA)
+		serverCA = resources.GetRootShardCAName(rootShard, operatorv1alpha1.ServerCA)
 
 	case kc.Spec.Target.ShardRef != nil:
-		var shard operatorv1alpha1.Shard
-		if err := r.Get(ctx, types.NamespacedName{Name: kc.Spec.Target.ShardRef.Name, Namespace: req.Namespace}, &shard); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Name: kc.Spec.Target.ShardRef.Name, Namespace: req.Namespace}, shard); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Shard: %w", err)
 		}
 
@@ -99,16 +98,13 @@ func (r *KubeconfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if ref == nil || ref.Name == "" {
 			return ctrl.Result{}, errors.New("the Shard does not reference a (valid) RootShard")
 		}
-		var rootShard operatorv1alpha1.RootShard
-		if err := r.Get(ctx, types.NamespacedName{Name: ref.Name, Namespace: req.Namespace}, &rootShard); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Name: ref.Name, Namespace: req.Namespace}, rootShard); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get RootShard: %w", err)
 		}
 
 		// The client CA is shared among all shards and owned by the root shard.
-		clientCertIssuer = resources.GetRootShardCAName(&rootShard, operatorv1alpha1.ClientCA)
-		serverCA = resources.GetRootShardCAName(&rootShard, operatorv1alpha1.ServerCA)
-		serverURL = resources.GetShardBaseURL(&shard)
-		serverName = shard.Name
+		clientCertIssuer = resources.GetRootShardCAName(rootShard, operatorv1alpha1.ClientCA)
+		serverCA = resources.GetRootShardCAName(rootShard, operatorv1alpha1.ServerCA)
 
 	case kc.Spec.Target.FrontProxyRef != nil:
 		var frontProxy operatorv1alpha1.FrontProxy
@@ -120,15 +116,12 @@ func (r *KubeconfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if ref == nil || ref.Name == "" {
 			return ctrl.Result{}, errors.New("the FrontProxy does not reference a (valid) RootShard")
 		}
-		var rootShard operatorv1alpha1.RootShard
-		if err := r.Get(ctx, types.NamespacedName{Name: frontProxy.Spec.RootShard.Reference.Name, Namespace: req.Namespace}, &rootShard); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Name: frontProxy.Spec.RootShard.Reference.Name, Namespace: req.Namespace}, rootShard); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get RootShard: %w", err)
 		}
 
-		clientCertIssuer = resources.GetRootShardCAName(&rootShard, operatorv1alpha1.FrontProxyClientCA)
-		serverCA = resources.GetRootShardCAName(&rootShard, operatorv1alpha1.ServerCA)
-		serverURL = fmt.Sprintf("https://%s:6443", rootShard.Spec.External.Hostname)
-		serverName = rootShard.Spec.External.Hostname
+		clientCertIssuer = resources.GetRootShardCAName(rootShard, operatorv1alpha1.FrontProxyClientCA)
+		serverCA = resources.GetRootShardCAName(rootShard, operatorv1alpha1.ServerCA)
 
 	default:
 		return ctrl.Result{}, fmt.Errorf("no valid target for kubeconfig found")
@@ -156,14 +149,12 @@ func (r *KubeconfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 	}
 
-	rootWSURL, err := url.JoinPath(serverURL, "clusters", "root")
+	reconciler, err := kubeconfig.KubeconfigSecretReconciler(&kc, rootShard, shard, serverCASecret, clientCertSecret)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if err := k8creconciling.ReconcileSecrets(ctx, []k8creconciling.NamedSecretReconcilerFactory{
-		kubeconfig.KubeconfigSecretReconciler(&kc, serverCASecret, clientCertSecret, serverName, rootWSURL),
-	}, req.Namespace, r.Client); err != nil {
+	if err := k8creconciling.ReconcileSecrets(ctx, []k8creconciling.NamedSecretReconcilerFactory{reconciler}, req.Namespace, r.Client); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/kubeconfig_controller.go
+++ b/internal/controller/kubeconfig_controller.go
@@ -27,6 +27,7 @@ import (
 	k8creconciling "k8c.io/reconciler/pkg/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -69,6 +70,10 @@ func (r *KubeconfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	var kc operatorv1alpha1.Kubeconfig
 	if err := r.Get(ctx, req.NamespacedName, &kc); err != nil {
+		// object has been deleted.
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
 	}
 

--- a/internal/resources/kubeconfig/secret.go
+++ b/internal/resources/kubeconfig/secret.go
@@ -30,6 +30,12 @@ import (
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
+const (
+	baseContext      string = "base"
+	shardBaseContext string = "shard-base"
+	defaultContext   string = "default"
+)
+
 func KubeconfigSecretReconciler(
 	kubeconfig *operatorv1alpha1.Kubeconfig,
 	rootShard *operatorv1alpha1.RootShard,
@@ -72,12 +78,12 @@ func KubeconfigSecretReconciler(
 			return nil, err
 		}
 
-		addCluster("default", defaultURL)
-		addContext("default", "default")
-		addCluster("base", serverURL)
-		addContext("base", "base")
-		addContext("shard-base", "base")
-		config.CurrentContext = "default"
+		addCluster(defaultContext, defaultURL)
+		addContext(defaultContext, defaultContext)
+		addCluster(baseContext, serverURL)
+		addContext(baseContext, baseContext)
+		addContext(shardBaseContext, baseContext)
+		config.CurrentContext = defaultContext
 
 	case kubeconfig.Spec.Target.ShardRef != nil:
 		if shard == nil {
@@ -90,12 +96,12 @@ func KubeconfigSecretReconciler(
 			return nil, err
 		}
 
-		addCluster("default", defaultURL)
-		addContext("default", "default")
-		addCluster("base", serverURL)
-		addContext("base", "base")
-		addContext("shard-base", "base")
-		config.CurrentContext = "default"
+		addCluster(defaultContext, defaultURL)
+		addContext(defaultContext, defaultContext)
+		addCluster(baseContext, serverURL)
+		addContext(baseContext, baseContext)
+		addContext(shardBaseContext, baseContext)
+		config.CurrentContext = defaultContext
 
 	case kubeconfig.Spec.Target.FrontProxyRef != nil:
 		if rootShard == nil {
@@ -108,11 +114,11 @@ func KubeconfigSecretReconciler(
 			return nil, err
 		}
 
-		addCluster("base", serverURL)
-		addCluster("default", defaultURL)
-		addContext("default", "default")
-		addContext("base", "base")
-		config.CurrentContext = "default"
+		addCluster(baseContext, serverURL)
+		addCluster(defaultContext, defaultURL)
+		addContext(defaultContext, defaultContext)
+		addContext(baseContext, baseContext)
+		config.CurrentContext = defaultContext
 
 	default:
 		panic("Called reconciler for an invalid kubeconfig, this should not have happened.")


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Updated version of #47, adding some more fields to sample objects in `config/samples` and new `Kubeconfig` objects for specific target references.

This continues some of the work started in #47, namely aligning kubeconfig context names with what the kcp e2e tests (not part of this PR for now) expect (`default`/`base`/`shard-base`). It also extends the samples given in `config/samples` with more annotated objects useful when getting started with the operator.

## What Type of PR Is This?

/kind feature

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
