### PR TITLE
Document correct release branch naming scheme

### DIFF
--- a/docs/content/contributing/releasing.md
+++ b/docs/content/contributing/releasing.md
@@ -21,8 +21,8 @@ tag represents where the corresponding `release/v0.X` branch branches off.
 1. Tag the main module: `git tag -m "version 0.X" v0.X.0`
 1. Tag the SDK module: `git tag -m "SDK version 0.X" sdk/v0.X.0`
 1. Push the tags: `git push upstream v0.X.0 sdk/v0.X.0`
-1. Create the release branch: `git checkout -B release/v0.X`
-1. Push the release branch: `git push -u upstream release/v0.X`
+1. Create the release branch: `git checkout -B release-0.X`
+1. Push the release branch: `git push -u upstream release-0.X`
 
 ## Patch Releases
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Pushed the wrong branch name because the docs are incorrect on this (kcp follows the same schema).

## What Type of PR Is This?

/kind documentation

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
