### PR TITLE
Fix external hostname for root shard

### DIFF
--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -112,7 +112,7 @@ func GetRootShardExternalBaseURL(r *operatorv1alpha1.RootShard) string {
 		clusterDomain = "cluster.local"
 	}
 
-	return fmt.Sprintf("%s-shard-kcp.%s.svc.%s", r.Name, r.Namespace, clusterDomain)
+	return fmt.Sprintf("%s-kcp.%s.svc.%s", r.Name, r.Namespace, clusterDomain)
 }
 
 func GetShardBaseHost(s *operatorv1alpha1.Shard) string {

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -106,6 +106,15 @@ func GetRootShardBaseURL(r *operatorv1alpha1.RootShard) string {
 	return fmt.Sprintf("https://%s:6443", GetRootShardBaseHost(r))
 }
 
+func GetRootShardExternalBaseURL(r *operatorv1alpha1.RootShard) string {
+	clusterDomain := r.Spec.ClusterDomain
+	if clusterDomain == "" {
+		clusterDomain = "cluster.local"
+	}
+
+	return fmt.Sprintf("%s-shard-kcp.%s.svc.%s", r.Name, r.Namespace, clusterDomain)
+}
+
 func GetShardBaseHost(s *operatorv1alpha1.Shard) string {
 	clusterDomain := s.Spec.ClusterDomain
 	if clusterDomain == "" {

--- a/internal/resources/rootshard/deployment.go
+++ b/internal/resources/rootshard/deployment.go
@@ -169,6 +169,7 @@ func getArgs(rootShard *operatorv1alpha1.RootShard) []string {
 		fmt.Sprintf("--service-account-private-key-file=%s/tls.key", getCertificateMountPath(operatorv1alpha1.ServiceAccountCertificate)),
 
 		// General shard configuration.
+		fmt.Sprintf("--external-hostname=%s", resources.GetRootShardExternalBaseURL(rootShard)),
 		fmt.Sprintf("--shard-base-url=%s", resources.GetRootShardBaseURL(rootShard)),
 		fmt.Sprintf("--shard-external-url=https://%s:%d", rootShard.Spec.External.Hostname, rootShard.Spec.External.Port),
 		fmt.Sprintf("--logical-cluster-admin-kubeconfig=%s/kubeconfig", getKubeconfigMountPath(operatorv1alpha1.LogicalClusterAdminCertificate)),


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

After the change:

```
virtualWorkspaces:
    - url: https://alpha-shard-kcp.kcp-faros.svc.cluster.local:6443/services/apiexport/36nt823y7lbbeust/tenancy.faros.sh
    - url: https://root-shard-kcp.kcp-faros.svc.cluster.local:6443/services/apiexport/36nt823y7lbbeust/tenancy.faros.sh
```


## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #https://github.com/kcp-dev/kcp-operator/issues/69

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix root shard URL setting
```
