### PR TITLE
Add virtualWorkspace & baseURL flag

### DIFF
--- a/internal/resources/rootshard/deployment.go
+++ b/internal/resources/rootshard/deployment.go
@@ -171,6 +171,8 @@ func getArgs(rootShard *operatorv1alpha1.RootShard) []string {
 		// General shard configuration.
 		fmt.Sprintf("--shard-base-url=%s", resources.GetRootShardBaseURL(rootShard)),
 		fmt.Sprintf("--shard-external-url=https://%s:%d", rootShard.Spec.External.Hostname, rootShard.Spec.External.Port),
+		fmt.Sprintf("--shard-virtual-workspace-url=%s", resources.GetRootShardBaseURL(rootShard)),
+
 		fmt.Sprintf("--logical-cluster-admin-kubeconfig=%s/kubeconfig", getKubeconfigMountPath(operatorv1alpha1.LogicalClusterAdminCertificate)),
 		fmt.Sprintf("--external-logical-cluster-admin-kubeconfig=%s/kubeconfig", getKubeconfigMountPath(operatorv1alpha1.ExternalLogicalClusterAdminCertificate)),
 		fmt.Sprintf("--batteries-included=%s", strings.Join(utils.GetRootShardBatteries(rootShard), ",")),

--- a/internal/resources/shard/deployment.go
+++ b/internal/resources/shard/deployment.go
@@ -173,10 +173,11 @@ func getArgs(shard *operatorv1alpha1.Shard, rootShard *operatorv1alpha1.RootShar
 
 		// General shard configuration.
 		fmt.Sprintf("--shard-name=%s", shard.Name),
-		fmt.Sprintf("--shard-base-url=%s", resources.GetShardBaseURL(shard)),
-		fmt.Sprintf("--shard-external-url=https://%s:%d", rootShard.Spec.External.Hostname, rootShard.Spec.External.Port),
-		fmt.Sprintf("--external-hostname=%s", rootShard.Spec.External.Hostname),
+		fmt.Sprintf("--shard-base-url=%s", resources.GetShardBaseHost(shard)),
+		fmt.Sprintf("--shard-external-url=%s:%d", rootShard.Spec.External.Hostname, rootShard.Spec.External.Port),
+		fmt.Sprintf("--shard-virtual-workspace-url=%s", resources.GetShardBaseHost(shard)),
 
+		fmt.Sprintf("--external-hostname=%s", rootShard.Spec.External.Hostname),
 		fmt.Sprintf("--root-shard-kubeconfig-file=%s/kubeconfig", getKubeconfigMountPath(operatorv1alpha1.ClientCertificate)),
 		fmt.Sprintf("--cache-kubeconfig=%s/kubeconfig", getKubeconfigMountPath(operatorv1alpha1.ClientCertificate)),
 		fmt.Sprintf("--logical-cluster-admin-kubeconfig=%s/kubeconfig", getKubeconfigMountPath(operatorv1alpha1.LogicalClusterAdminCertificate)),


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

## What Type of PR Is This?

Now we need to provide baseURL for shards, as it will default to pod IP address. 
While VirtualWorkspaceURL is defaulted from baseURL, I added it for consistency and readability. Easier to read and reason about. Else you see the behaviour vs flags and don't understand what is happening.

These flags converts to shard object spec hence having them makes it easier to spot inconsistencies (they happen if you change flags but dont recreate shard object)_ 
```
  spec:
    baseURL: https://root-kcp.kcp-faros.svc.cluster.local:6443
    externalURL: https://frontproxy-front-proxy.kcp-faros.svc.cluster.local:6443
    virtualWorkspaceURL: https://root-kcp.kcp-faros.svc.cluster.local:6443
  ```

/kind bug
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
