### PR TITLE
Do not validate ServiceAccount tokens at the front-proxy layer

### DIFF
--- a/internal/resources/frontproxy/deployment.go
+++ b/internal/resources/frontproxy/deployment.go
@@ -251,7 +251,6 @@ var defaultArgs = []string{
 	"--tls-cert-file=/etc/kcp-front-proxy/tls/tls.crt",
 	"--client-ca-file=/etc/kcp-front-proxy/client-ca/tls.crt",
 	"--mapping-file=/etc/kcp-front-proxy/config/path-mapping.yaml",
-	"--service-account-key-file=/etc/kcp/tls/service-account/tls.key",
 }
 
 func getArgs(fps *operatorv1alpha1.FrontProxySpec) []string {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Looks like setting this flag (`--service-account-key-file`) on the front-proxy is a mistake because it will validate ServiceAccount tokens only against the PKI infrastructure of the root shard for ServiceAccounts, but not against other shards.

Disabling ServiceAccount validation on the front-proxy will let it pass through the request to the individual shard where it is successfully validated.

I've tested this on the kind setup and it seems to now work (i.e. ServiceAccount tokens generated for one workspace worked against the other), but I'm not 100% confident either. This should unblock using ServiceAccounts in a multi-shard environment, but further investigation might be needed (e.g. what is with cross-workspace ServiceAccounts? Afaik we support that now, but it might not be covered by the changes in this PR).

## What Type of PR Is This?

/kind bug
/kind cleanup

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Do not set `--service-account-key-file` on front-proxy to allow individual shards to authenticate tokens
```
