### PR TITLE
Update default kcp version to v0.28.0

### DIFF
--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	ImageRepository = "ghcr.io/kcp-dev/kcp"
-	ImageTag        = "v0.27.1"
+	ImageTag        = "v0.28.0"
 
 	appNameLabel      = "app.kubernetes.io/name"
 	appInstanceLabel  = "app.kubernetes.io/instance"


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This bumps the version to deploy with kcp-operator to [0.28.0](https://github.com/kcp-dev/kcp/releases/tag/v0.28.0).

## What Type of PR Is This?

/kind feature

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Deploy kcp [0.28.0](https://github.com/kcp-dev/kcp/releases/tag/v0.28.0) by default
```
