### PR TITLE
bump default kcp version to 0.28.1

### DIFF
--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	ImageRepository = "ghcr.io/kcp-dev/kcp"
-	ImageTag        = "v0.28.0"
+	ImageTag        = "v0.28.1"
 
 	appNameLabel      = "app.kubernetes.io/name"
 	appInstanceLabel  = "app.kubernetes.io/instance"


### PR DESCRIPTION
## Summary
0.28.1 has important fixes, to the point that nobody should ever use 0.28.0 (IMHO).

## What Type of PR Is This?
/kind feature

## Release Notes
```release-note
Update default kcp version to [0.28.1](https://github.com/kcp-dev/kcp/releases/tag/v0.28.1).
```
