### PR TITLE
Update default kcp tag to v0.28.3

### DIFF
--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	ImageRepository = "ghcr.io/kcp-dev/kcp"
-	ImageTag        = "v0.28.1"
+	ImageTag        = "v0.28.3"
 
 	appNameLabel      = "app.kubernetes.io/name"
 	appInstanceLabel  = "app.kubernetes.io/instance"


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

We just relased v0.28.3, we should bump the default version here. I suppose we also should backport and cut 0.2.1.

## What Type of PR Is This?

/kind feature

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Update default kcp version to [v0.28.3](https://github.com/kcp-dev/kcp/releases/tag/v0.28.3)
```
