### PR TITLE
Add to override issuer on shard certificate template

### DIFF
--- a/config/crd/bases/operator.kcp.io_frontproxies.yaml
+++ b/config/crd/bases/operator.kcp.io_frontproxies.yaml
@@ -188,6 +188,9 @@ spec:
                           description: |-
                             Requested DNS subject alternative names. The values given here will be merged into the
                             DNS names determined automatically by the kcp-operator.
+                            If DNSNames is used together with IssuerRef, DNSNames will be uses as-is and not merged.
+                            If IssuerRef is not set, DNSNames will be merged with the defaults. This is to avoid
+                            trying to guess what DNSNames configued issuer might support.
                           items:
                             type: string
                           type: array
@@ -208,6 +211,22 @@ spec:
                           items:
                             type: string
                           type: array
+                        issuerRef:
+                          description: IssuerRef is a reference to the issuer for
+                            this certificate.
+                          properties:
+                            group:
+                              description: Group of the object being referred to.
+                              type: string
+                            kind:
+                              description: Kind of the object being referred to.
+                              type: string
+                            name:
+                              description: Name of the object being referred to.
+                              type: string
+                          required:
+                          - name
+                          type: object
                         privateKey:
                           description: |-
                             Private key options. These include the key algorithm and size, the used

--- a/config/crd/bases/operator.kcp.io_kubeconfigs.yaml
+++ b/config/crd/bases/operator.kcp.io_kubeconfigs.yaml
@@ -65,6 +65,9 @@ spec:
                         description: |-
                           Requested DNS subject alternative names. The values given here will be merged into the
                           DNS names determined automatically by the kcp-operator.
+                          If DNSNames is used together with IssuerRef, DNSNames will be uses as-is and not merged.
+                          If IssuerRef is not set, DNSNames will be merged with the defaults. This is to avoid
+                          trying to guess what DNSNames configued issuer might support.
                         items:
                           type: string
                         type: array
@@ -85,6 +88,22 @@ spec:
                         items:
                           type: string
                         type: array
+                      issuerRef:
+                        description: IssuerRef is a reference to the issuer for this
+                          certificate.
+                        properties:
+                          group:
+                            description: Group of the object being referred to.
+                            type: string
+                          kind:
+                            description: Kind of the object being referred to.
+                            type: string
+                          name:
+                            description: Name of the object being referred to.
+                            type: string
+                        required:
+                        - name
+                        type: object
                       privateKey:
                         description: |-
                           Private key options. These include the key algorithm and size, the used

--- a/config/crd/bases/operator.kcp.io_rootshards.yaml
+++ b/config/crd/bases/operator.kcp.io_rootshards.yaml
@@ -274,6 +274,9 @@ spec:
                           description: |-
                             Requested DNS subject alternative names. The values given here will be merged into the
                             DNS names determined automatically by the kcp-operator.
+                            If DNSNames is used together with IssuerRef, DNSNames will be uses as-is and not merged.
+                            If IssuerRef is not set, DNSNames will be merged with the defaults. This is to avoid
+                            trying to guess what DNSNames configued issuer might support.
                           items:
                             type: string
                           type: array
@@ -294,6 +297,22 @@ spec:
                           items:
                             type: string
                           type: array
+                        issuerRef:
+                          description: IssuerRef is a reference to the issuer for
+                            this certificate.
+                          properties:
+                            group:
+                              description: Group of the object being referred to.
+                              type: string
+                            kind:
+                              description: Kind of the object being referred to.
+                              type: string
+                            name:
+                              description: Name of the object being referred to.
+                              type: string
+                          required:
+                          - name
+                          type: object
                         privateKey:
                           description: |-
                             Private key options. These include the key algorithm and size, the used
@@ -1691,6 +1710,9 @@ spec:
                               description: |-
                                 Requested DNS subject alternative names. The values given here will be merged into the
                                 DNS names determined automatically by the kcp-operator.
+                                If DNSNames is used together with IssuerRef, DNSNames will be uses as-is and not merged.
+                                If IssuerRef is not set, DNSNames will be merged with the defaults. This is to avoid
+                                trying to guess what DNSNames configued issuer might support.
                               items:
                                 type: string
                               type: array
@@ -1711,6 +1733,23 @@ spec:
                               items:
                                 type: string
                               type: array
+                            issuerRef:
+                              description: IssuerRef is a reference to the issuer
+                                for this certificate.
+                              properties:
+                                group:
+                                  description: Group of the object being referred
+                                    to.
+                                  type: string
+                                kind:
+                                  description: Kind of the object being referred to.
+                                  type: string
+                                name:
+                                  description: Name of the object being referred to.
+                                  type: string
+                              required:
+                              - name
+                              type: object
                             privateKey:
                               description: |-
                                 Private key options. These include the key algorithm and size, the used

--- a/config/crd/bases/operator.kcp.io_shards.yaml
+++ b/config/crd/bases/operator.kcp.io_shards.yaml
@@ -258,6 +258,9 @@ spec:
                           description: |-
                             Requested DNS subject alternative names. The values given here will be merged into the
                             DNS names determined automatically by the kcp-operator.
+                            If DNSNames is used together with IssuerRef, DNSNames will be uses as-is and not merged.
+                            If IssuerRef is not set, DNSNames will be merged with the defaults. This is to avoid
+                            trying to guess what DNSNames configued issuer might support.
                           items:
                             type: string
                           type: array
@@ -278,6 +281,22 @@ spec:
                           items:
                             type: string
                           type: array
+                        issuerRef:
+                          description: IssuerRef is a reference to the issuer for
+                            this certificate.
+                          properties:
+                            group:
+                              description: Group of the object being referred to.
+                              type: string
+                            kind:
+                              description: Kind of the object being referred to.
+                              type: string
+                            name:
+                              description: Name of the object being referred to.
+                              type: string
+                          required:
+                          - name
+                          type: object
                         privateKey:
                           description: |-
                             Private key options. These include the key algorithm and size, the used

--- a/sdk/apis/operator/v1alpha1/common.go
+++ b/sdk/apis/operator/v1alpha1/common.go
@@ -134,8 +134,16 @@ type CertificateSpecTemplate struct {
 	// +optional
 	Subject *X509Subject `json:"subject,omitempty"`
 
+	// IssuerRef is a reference to the issuer for this certificate.
+	//
+	// +optional
+	IssuerRef *ObjectReference `json:"issuerRef"`
+
 	// Requested DNS subject alternative names. The values given here will be merged into the
 	// DNS names determined automatically by the kcp-operator.
+	// If DNSNames is used together with IssuerRef, DNSNames will be uses as-is and not merged.
+	// If IssuerRef is not set, DNSNames will be merged with the defaults. This is to avoid
+	// trying to guess what DNSNames configued issuer might support.
 	//
 	// +optional
 	DNSNames []string `json:"dnsNames,omitempty"`

--- a/sdk/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/sdk/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -336,6 +336,11 @@ func (in *CertificateSpecTemplate) DeepCopyInto(out *CertificateSpecTemplate) {
 		*out = new(X509Subject)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.IssuerRef != nil {
+		in, out := &in.IssuerRef, &out.IssuerRef
+		*out = new(ObjectReference)
+		**out = **in
+	}
 	if in.DNSNames != nil {
 		in, out := &in.DNSNames, &out.DNSNames
 		*out = make([]string, len(*in))

--- a/sdk/applyconfiguration/operator/v1alpha1/certificatespectemplate.go
+++ b/sdk/applyconfiguration/operator/v1alpha1/certificatespectemplate.go
@@ -26,6 +26,7 @@ import (
 // with apply.
 type CertificateSpecTemplateApplyConfiguration struct {
 	Subject        *X509SubjectApplyConfiguration                   `json:"subject,omitempty"`
+	IssuerRef      *ObjectReferenceApplyConfiguration               `json:"issuerRef,omitempty"`
 	DNSNames       []string                                         `json:"dnsNames,omitempty"`
 	IPAddresses    []string                                         `json:"ipAddresses,omitempty"`
 	SecretTemplate *CertificateSecretTemplateApplyConfiguration     `json:"secretTemplate,omitempty"`
@@ -45,6 +46,14 @@ func CertificateSpecTemplate() *CertificateSpecTemplateApplyConfiguration {
 // If called multiple times, the Subject field is set to the value of the last call.
 func (b *CertificateSpecTemplateApplyConfiguration) WithSubject(value *X509SubjectApplyConfiguration) *CertificateSpecTemplateApplyConfiguration {
 	b.Subject = value
+	return b
+}
+
+// WithIssuerRef sets the IssuerRef field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the IssuerRef field is set to the value of the last call.
+func (b *CertificateSpecTemplateApplyConfiguration) WithIssuerRef(value *ObjectReferenceApplyConfiguration) *CertificateSpecTemplateApplyConfiguration {
+	b.IssuerRef = value
 	return b
 }
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

## What Type of PR Is This?
/kind feature

Allow fully override issuer when configuring certificateTemplate

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Allow to override issuer when configuring CertificateTemplate on shards
```
