### PR TITLE
Update to Go 1.24.9

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # tag=v5.4.0
         with:
-          go-version: v1.24.8
+          go-version: v1.24.9
           cache: true
 
       - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 #tag=v5.5.0

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-3
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - make
             - verify
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-3
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - make
             - lint
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-3
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - make
             - test
@@ -86,7 +86,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-3
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - hack/ci/run-e2e-tests.sh
           resources:
@@ -106,7 +106,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-3
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.8 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.9 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Follow-up to #112 because Go 1.24.8 has a known issue with parsing X509 certificates, which seems to affect some of our pipelines.

## What Type of PR Is This?

/kind cleanup

## Related Issue(s)

Towards https://github.com/kcp-dev/infra/issues/136

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
kcp-operator is built with Go 1.24.9
```
