### PR TITLE
fix: check if external.hostname is empty to not set an invalid value to the certificate

### DIFF
--- a/internal/resources/frontproxy/certificates.go
+++ b/internal/resources/frontproxy/certificates.go
@@ -91,7 +91,7 @@ func (r *reconciler) serverCertificateReconciler() reconciling.NamedCertificateR
 		// to not break existing front-proxy installations.
 		if r.frontProxy.Spec.ExternalHostname != "" {
 			dnsNames = append(dnsNames, r.frontProxy.Spec.ExternalHostname)
-		} else {
+		} else if r.frontProxy.Spec.External.Hostname != "" {
 			dnsNames = append(dnsNames, r.frontProxy.Spec.External.Hostname)
 		}
 	}


### PR DESCRIPTION
## Summary

## What Type of PR Is This?

/kind bug

## Related Issue(s)

Currently, if the `.spec.external.hostname` of a `FrontProxy` resource is empty, it just gets set on the created certificate, which will result in a tls error, when trying interact with that proxy through a go client. `kubectl` does not complain, but a golang client will complain about an invalid dnsName attributes inside the server certificate.

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
