### PR TITLE
add kcp operator custom metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/kcp-dev/kcp-operator/sdk v0.0.0-00010101000000-000000000000
 	github.com/kcp-dev/kcp/sdk v0.27.1
 	github.com/kcp-dev/logicalcluster/v3 v3.0.5
+	github.com/prometheus/client_golang v1.20.5
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0
 	k8c.io/reconciler v0.5.0
@@ -68,7 +69,6 @@ require (
 	github.com/onsi/gomega v1.35.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.20.5 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.61.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2025 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"time"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+const (
+	UnknownPhase = "Unknown"
+)
+
+type MetricsCollector struct {
+	client ctrlruntimeclient.Client
+}
+
+func NewMetricsCollector(client ctrlruntimeclient.Client) *MetricsCollector {
+	return &MetricsCollector{
+		client: client,
+	}
+}
+
+func (mc *MetricsCollector) Start(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	mc.updateObjectCounts(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			mc.updateObjectCounts(ctx)
+		}
+	}
+}
+
+func (mc *MetricsCollector) updateObjectCounts(ctx context.Context) {
+	mc.updateRootShardCounts(ctx)
+	mc.updateShardCounts(ctx)
+	mc.updateFrontProxyCounts(ctx)
+	mc.updateCacheServerCounts(ctx)
+	mc.updateKubeconfigCounts(ctx)
+}
+
+func (mc *MetricsCollector) updateRootShardCounts(ctx context.Context) {
+	var rootShards operatorv1alpha1.RootShardList
+	if err := mc.client.List(ctx, &rootShards); err != nil {
+		return
+	}
+
+	RootShardCount.Reset()
+
+	phaseCounts := make(map[string]map[string]int)
+	for _, rs := range rootShards.Items {
+		phase := string(rs.Status.Phase)
+		if phase == "" {
+			phase = UnknownPhase
+		}
+		if phaseCounts[phase] == nil {
+			phaseCounts[phase] = make(map[string]int)
+		}
+		phaseCounts[phase][rs.Namespace]++
+	}
+
+	for phase, namespaceCounts := range phaseCounts {
+		for namespace, count := range namespaceCounts {
+			RootShardCount.WithLabelValues(phase, namespace).Set(float64(count))
+		}
+	}
+}
+
+func (mc *MetricsCollector) updateShardCounts(ctx context.Context) {
+	var shards operatorv1alpha1.ShardList
+	if err := mc.client.List(ctx, &shards); err != nil {
+		return
+	}
+
+	ShardCount.Reset()
+
+	phaseCounts := make(map[string]map[string]int)
+	for _, s := range shards.Items {
+		phase := string(s.Status.Phase)
+		if phase == "" {
+			phase = UnknownPhase
+		}
+		if phaseCounts[phase] == nil {
+			phaseCounts[phase] = make(map[string]int)
+		}
+		phaseCounts[phase][s.Namespace]++
+	}
+
+	for phase, namespaceCounts := range phaseCounts {
+		for namespace, count := range namespaceCounts {
+			ShardCount.WithLabelValues(phase, namespace).Set(float64(count))
+		}
+	}
+}
+
+func (mc *MetricsCollector) updateFrontProxyCounts(ctx context.Context) {
+	var frontProxies operatorv1alpha1.FrontProxyList
+	if err := mc.client.List(ctx, &frontProxies); err != nil {
+		return
+	}
+
+	FrontProxyCount.Reset()
+
+	phaseCounts := make(map[string]map[string]int)
+	for _, fp := range frontProxies.Items {
+		phase := string(fp.Status.Phase)
+		if phase == "" {
+			phase = UnknownPhase
+		}
+		if phaseCounts[phase] == nil {
+			phaseCounts[phase] = make(map[string]int)
+		}
+		phaseCounts[phase][fp.Namespace]++
+	}
+
+	for phase, namespaceCounts := range phaseCounts {
+		for namespace, count := range namespaceCounts {
+			FrontProxyCount.WithLabelValues(phase, namespace).Set(float64(count))
+		}
+	}
+}
+
+func (mc *MetricsCollector) updateCacheServerCounts(ctx context.Context) {
+	var cacheServers operatorv1alpha1.CacheServerList
+	if err := mc.client.List(ctx, &cacheServers); err != nil {
+		return
+	}
+
+	CacheServerCount.Reset()
+
+	namespaceCounts := make(map[string]int)
+	for _, cs := range cacheServers.Items {
+		namespaceCounts[cs.Namespace]++
+	}
+
+	for namespace, count := range namespaceCounts {
+		CacheServerCount.WithLabelValues(namespace).Set(float64(count))
+	}
+}
+
+func (mc *MetricsCollector) updateKubeconfigCounts(ctx context.Context) {
+	var kubeconfigs operatorv1alpha1.KubeconfigList
+	if err := mc.client.List(ctx, &kubeconfigs); err != nil {
+		return
+	}
+
+	KubeconfigCount.Reset()
+
+	namespaceCounts := make(map[string]int)
+	for _, kc := range kubeconfigs.Items {
+		namespaceCounts[kc.Namespace]++
+	}
+
+	for namespace, count := range namespaceCounts {
+		KubeconfigCount.WithLabelValues(namespace).Set(float64(count))
+	}
+}

--- a/internal/metrics/helpers.go
+++ b/internal/metrics/helpers.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2025 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	RootShardResourceType   = "rootshard"
+	ShardResourceType       = "shard"
+	FrontProxyResourceType  = "frontproxy"
+	CacheServerResourceType = "cacheserver"
+	KubeconfigResourceType  = "kubeconfig"
+)
+
+// RecordObjectMetrics records metrics for a Kubernetes object with phase and conditions
+func RecordObjectMetrics(resourceType, resourceName, namespace, phase string, conditions []metav1.Condition) {
+	if phase == "" {
+		phase = "Unknown"
+	}
+
+	switch resourceType {
+	case RootShardResourceType:
+		RootShardCount.WithLabelValues(phase, namespace).Set(1)
+	case ShardResourceType:
+		ShardCount.WithLabelValues(phase, namespace).Set(1)
+	case FrontProxyResourceType:
+		FrontProxyCount.WithLabelValues(phase, namespace).Set(1)
+	case CacheServerResourceType:
+		CacheServerCount.WithLabelValues(namespace).Set(1)
+	case KubeconfigResourceType:
+		KubeconfigCount.WithLabelValues(namespace).Set(1)
+	}
+
+	for _, condition := range conditions {
+		status := 0.0
+		switch condition.Status {
+		case metav1.ConditionTrue:
+			status = 1.0
+		case metav1.ConditionFalse:
+			status = 0.0
+		case metav1.ConditionUnknown:
+			status = -1.0
+		}
+
+		ConditionStatus.WithLabelValues(
+			resourceType,
+			resourceName,
+			namespace,
+			condition.Type,
+		).Set(status)
+	}
+}
+
+// RecordReconciliationMetrics records reconciliation duration and error metrics
+func RecordReconciliationMetrics(controller string, duration float64, err error) {
+	result := "success"
+	if err != nil {
+		result = "error"
+		ReconciliationErrors.WithLabelValues(controller, "reconcile_error").Inc()
+	}
+	ReconciliationDuration.WithLabelValues(controller, result).Observe(duration)
+}
+
+// RecordReconciliationError records a specific reconciliation error
+func RecordReconciliationError(controller, errorType string) {
+	ReconciliationErrors.WithLabelValues(controller, errorType).Inc()
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2025 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	ctrlruntimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// RootShardCount tracks the number of RootShard objects by their current phase.
+	// Labels: phase (Provisioning|Running|Deleting), namespace
+	RootShardCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kcp_operator_rootshard_count",
+			Help: "Number of RootShard objects by phase",
+		},
+		[]string{"phase", "namespace"},
+	)
+
+	// ShardCount tracks the number of Shard objects by their current phase.
+	// Labels: phase (Provisioning|Running|Deleting), namespace
+	ShardCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kcp_operator_shard_count",
+			Help: "Number of Shard objects by phase",
+		},
+		[]string{"phase", "namespace"},
+	)
+
+	// FrontProxyCount tracks the number of FrontProxy objects by their current phase.
+	// Labels: phase (Provisioning|Running|Deleting), namespace
+	FrontProxyCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kcp_operator_frontproxy_count",
+			Help: "Number of FrontProxy objects by phase",
+		},
+		[]string{"phase", "namespace"},
+	)
+
+	// CacheServerCount tracks the number of CacheServer objects by namespace.
+	// Labels: namespace
+	CacheServerCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kcp_operator_cacheserver_count",
+			Help: "Number of CacheServer objects by namespace",
+		},
+		[]string{"namespace"},
+	)
+
+	// KubeconfigCount tracks the number of Kubeconfig objects by namespace.
+	// Labels: namespace
+	KubeconfigCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kcp_operator_kubeconfig_count",
+			Help: "Number of Kubeconfig objects by namespace",
+		},
+		[]string{"namespace"},
+	)
+
+	// ReconciliationDuration measures the time taken to reconcile kcp operator resources.
+	// Labels: controller (rootshard|shard|frontproxy|kubeconfig|cacheserver), result (success|error)
+	ReconciliationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "kcp_operator_reconciliation_duration_seconds",
+			Help:    "Time taken to reconcile objects",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"controller", "result"},
+	)
+
+	// ReconciliationErrors counts the total number of reconciliation errors by controller and error type.
+	// Labels: controller (rootshard|shard|frontproxy|kubeconfig|cacheserver), error_type
+	ReconciliationErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kcp_operator_reconciliation_errors_total",
+			Help: "Total number of reconciliation errors",
+		},
+		[]string{"controller", "error_type"},
+	)
+
+	// ConditionStatus tracks the status of conditions on kcp operator resources.
+	// Values: 1.0 (True), 0.0 (False), -1.0 (Unknown)
+	// Labels: resource_type (rootshard|shard|frontproxy|cacheserver|kubeconfig),
+	//         resource_name, namespace, condition_type (Available|RootShard)
+	ConditionStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kcp_operator_condition_status",
+			Help: "Status of conditions",
+		},
+		[]string{"resource_type", "resource_name", "namespace", "condition_type"},
+	)
+)
+
+func RegisterMetrics() {
+	ctrlruntimemetrics.Registry.MustRegister(
+		RootShardCount,
+		ShardCount,
+		FrontProxyCount,
+		CacheServerCount,
+		KubeconfigCount,
+		ReconciliationDuration,
+		ReconciliationErrors,
+		ConditionStatus,
+	)
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
```
Change adds custom kcp operator metrics to Prometheus
```
<img width="1382" height="872" alt="Screenshot 2025-10-24 at 06 48 57" src="https://github.com/user-attachments/assets/3b64ffba-999f-4d82-bdec-b7ea46ce58dd" />

## What Type of PR Is This?
/kind feature
<!--
/kind feature

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes [25](https://github.com/kcp-dev/kcp-operator/issues/25)

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note

Added custom kcp-operator metrics to prometheus
```
