### PR TITLE
update default kcp version to 0.29, add 0.28-based e2e test

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -77,7 +77,30 @@ presubmits:
               memory: 4Gi
               cpu: 2
 
-  - name: pull-kcp-operator-test-e2e
+  - name: pull-kcp-operator-test-e2e-0.28
+    decorate: true
+    run_if_changed: "(Dockerfile|Makefile|.prow.yaml|go.mod|go.sum|cmd|internal|sdk|hack|test)"
+    optional: false
+    clone_uri: "https://github.com/kcp-dev/kcp-operator"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+          command:
+            - hack/ci/run-e2e-tests.sh
+          env:
+            - name: KCP_TAG
+              value: release-0.28
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+
+  - name: pull-kcp-operator-test-e2e-default
     decorate: true
     run_if_changed: "(Dockerfile|Makefile|.prow.yaml|go.mod|go.sum|cmd|internal|sdk|hack|test)"
     optional: false

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -23,6 +23,7 @@ The table below marks known support of a kcp version in kcp-operator versions.
 | kcp    | `main`             | 0.1.x              |
 | ------ | ------------------ | ------------------ |
 | `main` | :warning:          | :question:         |
+| 0.29.x | :white_check_mark: | :question:         |
 | 0.28.x | :white_check_mark: | :question:         |
 | 0.27.x | :question:         | :white_check_mark: |
 

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	ImageRepository = "ghcr.io/kcp-dev/kcp"
-	ImageTag        = "v0.28.3"
+	ImageTag        = "v0.29.0"
 
 	appNameLabel      = "app.kubernetes.io/name"
 	appInstanceLabel  = "app.kubernetes.io/instance"


### PR DESCRIPTION
## Summary
kcp 0.29 was just released, let's support it out of  the box.

## What Type of PR Is This?
/kind cleanup

## Release Notes
```release-note
Update default kcp version to 0.29.0.
```
