### PR TITLE
update to Go 1.24.11, update actions

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -26,17 +26,20 @@ jobs:
     name: Generate and push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # tag=v6.0.1
 
       - run: git fetch origin gh-pages
       - run: git fetch origin '+refs/tags/v*:refs/tags/v*' --no-tags
 
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # tag=v5.4.0
+      - name: Setup Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # tag=v6.1.0
         with:
-          go-version: v1.24.9
+          go-version: v1.24.11
           cache: true
 
-      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 #tag=v5.5.0
+      - name: Setup Python
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 #tag=v6.1.0
         with:
           python-version: "3.10"
           cache: "pip"

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
           command:
             - make
             - verify
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
           command:
             - make
             - lint
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
           command:
             - make
             - test
@@ -86,7 +86,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
           command:
             - hack/ci/run-e2e-tests.sh
           resources:
@@ -106,7 +106,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.9 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.11 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
Go 1.24.11 was just released, this updates our configs accordingly. Since the download URL for Go changed, we also at least have to update the setup-go action to 6.1.0+.

## What Type of PR Is This?
/kind chore

## Release Notes
```release-note
Update to Go 1.24.11.
```
