### PR TITLE
fix panic when resource requests and limit are added to frontproxy

### DIFF
--- a/internal/resources/utils/deployments.go
+++ b/internal/resources/utils/deployments.go
@@ -78,6 +78,13 @@ func ApplyResources(container corev1.Container, resources *corev1.ResourceRequir
 		return container
 	}
 
+	if container.Resources.Limits == nil {
+		container.Resources.Limits = make(corev1.ResourceList)
+	}
+	if container.Resources.Requests == nil {
+		container.Resources.Requests = make(corev1.ResourceList)
+	}
+
 	maps.Copy(container.Resources.Limits, resources.Limits)
 	maps.Copy(container.Resources.Requests, resources.Requests)
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
```
change fixes panic when resource request and limit
are added to the front-proxy custom resource.
```

## What Type of PR Is This?
/kind bug
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes [131](https://github.com/kcp-dev/kcp-operator/issues/131)

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fixed panic when resource request and or limit are added to the front-proxy custom resource.
```
