### PR TITLE
Remove obsolete Makefile targets from target dependency lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,9 @@ go.work.sum
 # Downloaded and built binaries
 /_build/
 /_tools/
+/dist/
 
 # e2e test logs and artifacts
 /.e2e-*
 .vscode
+.idea

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ KUSTOMIZE = $(abspath .)/$(UGET_DIRECTORY)/kustomize-$(KUSTOMIZE_VERSION)
 KUBECTL = $(abspath .)/$(UGET_DIRECTORY)/kubectl-$(KUBECTL_VERSION)
 
 .PHONY: build-installer
-build-installer: manifests generate install-kustomize ## Generate a consolidated YAML with CRDs and deployment.
+build-installer: codegen install-kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > dist/install.yaml


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

After previous Makefile refactorings several targets still use dependencies to removed targets.

## What Type of PR Is This?

/kind bug
/kind regression

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
