### PR TITLE
extend sample manifests to reflect external access

### DIFF
--- a/config/samples/operator.kcp.io_v1alpha1_frontproxy.yaml
+++ b/config/samples/operator.kcp.io_v1alpha1_frontproxy.yaml
@@ -14,6 +14,8 @@ spec:
       name: shard-sample
   serviceTemplate:
     spec:
+      # use type LoadBalancer for external access.
+      type: LoadBalancer
       # hard code a specific cluster IP, e.g. for a kind setup.
       clusterIP: 10.96.100.100
   certificateTemplates:

--- a/config/samples/operator.kcp.io_v1alpha1_rootshard.yaml
+++ b/config/samples/operator.kcp.io_v1alpha1_rootshard.yaml
@@ -6,6 +6,12 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: shard-sample
 spec:
+  # if APIExportEndpointSlices should provide publicly accessible shard endpoints
+  # (like the api endpoint described by field external, they require a public
+  # DNS name. These fields  must be set in secondary shards, also.
+  shardBaseURL: https://root.shard.example.operator.kcp.io:6443
+  # here, the external publicly accessible endpoint for kcp users is described.
+  # it is used for the frontproxy.
   external:
     hostname: example.operator.kcp.io
     port: 6443
@@ -14,12 +20,31 @@ spec:
       group: cert-manager.io
       kind: Issuer
       name: selfsigned
+  # if an external root shard DNS name is configured, it must be covered by the
+  # server certificate (in secondary shards, similarly).
+  certificateTemplates:
+    server:
+      spec:
+        dnsNames:
+        - root.shard.example.operator.kcp.io
+
+  # if the root shard should be externally available, the service requires a load-balancer.
+  # (in secondary shards, similarly)
+  serviceTemplate:
+    spec:
+      type: LoadBalancer
+
   cache:
     embedded:
       enabled: true
   etcd:
     endpoints:
       - http://etcd.default.svc.cluster.local:2379
+    # if https should be used the tlsSecret must be configured using the client secret
+    # from etcd (in secondary shards, similarly).
+    #tlsConfig;
+    #  secretRef:
+    #    name: etcd-client
   deploymentTemplate:
     spec:
       template:


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

The sample manifests under `config/samples` describe an external hostname in the rootshard manifest.
But the rest of the manifest and the matching frontproxy manifest do not completely match this feature.
Missing are:
- in the rootshard
  -  `shardBaseURL`
  -  additional server certificate SAN
  -  service type in `serviceTemplate`
- in the frontproxy
   -  service type in `serviceTemplate`
   
## What Type of PR Is This?
/kind documentation
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
