### PR TITLE
Fix defaulting LATEST

### DIFF
--- a/docs/scripts/deploy-docs.sh
+++ b/docs/scripts/deploy-docs.sh
@@ -49,7 +49,7 @@ if [[ -n "${BRANCH:-}" ]]; then
   MIKE_OPTIONS+=(--branch "$BRANCH")
 fi
 
-LATEST=$(git describe --tags --match="v[0-9]*" `git rev-list --tags --max-count=1` || echo "v0.0.0" | grep -o '^v[0-9]\+\.[0-9]\+')
+LATEST="$(git describe --tags --match='v[0-9]*' "$(git rev-list --tags --max-count=1)" | grep -o '^v[0-9]\+\.[0-9]\+' || echo 'v0.0.0')"
 if [[ "${LATEST:-}" == "${VERSION:-}" ]]; then
   MIKE_DEPLOY_OPTIONS+=(--update-aliases)
   MIKE_ALIASES+=(latest)


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Possible fix for #151 

I think the `| grep` only applies to the `echo v0.0.0` before it and not the plumbing commands.
So `git describe ...` was always getting the tag but with the whitespace around it and the `grep -o` didn't apply and that's why the comparison with `VERSION` always failed and the latest tag was never updated.

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
