### PR TITLE
prevent Go from printing 'command-line arguments' after building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/operator/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager ./cmd/operator/
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -152,8 +152,8 @@ clean-tools: ## Remove all downloaded tools.
 
 .PHONY: build
 build: ## Build manager binary.
-	go build $(GOTOOLFLAGS) -o $(BUILD_DEST)/manager cmd/operator/main.go
-	go build $(GOTOOLFLAGS) -o $(BUILD_DEST)/bundler cmd/bundle/main.go
+	go build $(GOTOOLFLAGS) -o $(BUILD_DEST)/manager ./cmd/operator/
+	go build $(GOTOOLFLAGS) -o $(BUILD_DEST)/bundler ./cmd/bundle/
 
 .PHONY: run
 run: fmt vet ## Run a controller from your host.


### PR DESCRIPTION
## Summary
Just a cosmetic fix to make the build log look nicer.

## What Type of PR Is This?
/kind bug

## Release Notes
```release-note
NONE
```
