### PR TITLE
fix local-cluster-admin kubeconfigs for shards not pointing to the shards

### DIFF
--- a/internal/resources/shard/kubeconfigs.go
+++ b/internal/resources/shard/kubeconfigs.go
@@ -99,7 +99,7 @@ func LogicalClusterAdminKubeconfigReconciler(shard *operatorv1alpha1.Shard, root
 			config = &clientcmdapi.Config{
 				Clusters: map[string]*clientcmdapi.Cluster{
 					serverName: {
-						Server:               resources.GetRootShardBaseURL(rootShard),
+						Server:               resources.GetShardBaseURL(shard),
 						CertificateAuthority: getCAMountPath(operatorv1alpha1.ServerCA) + "/tls.crt",
 					},
 				},


### PR DESCRIPTION
## Summary
I assume this was a simple copy-paste mistake I made when implementing shard support. At least I cannot imagine why all shards would be configured with a lca-kubeconfig that points to the root shard. @mjudeikis hinted that it's already curious that each shard gets a `--root-shard-kubeconfig-file`, since shard->rootShard communication should happen via front-proxy, no? (I hope I represented that thought correctly). So why would the lca-kubeconfig also point to the root shard?

## What Type of PR Is This?
/kind bug

## Release Notes
```release-note
Fix: A shard's `logical-cluster-admin` kubeconfig pointed to the root shard instead of the owning shard.
```
