### PR TITLE
Fix metrics

### DIFF
--- a/internal/controller/frontproxy/controller.go
+++ b/internal/controller/frontproxy/controller.go
@@ -119,8 +119,6 @@ func (r *FrontProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		recErr = kerrors.NewAggregate([]error{recErr, err})
 	}
 
-	metrics.RecordObjectMetrics(metrics.FrontProxyResourceType, &frontProxy, frontProxy.Status.Conditions)
-
 	return ctrl.Result{}, recErr
 }
 

--- a/internal/controller/kubeconfig/controller.go
+++ b/internal/controller/kubeconfig/controller.go
@@ -122,8 +122,6 @@ func (r *KubeconfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		recErr = kerrors.NewAggregate([]error{recErr, err})
 	}
 
-	metrics.RecordObjectMetrics(metrics.KubeconfigResourceType, &kc, kc.Status.Conditions)
-
 	return ctrl.Result{}, recErr
 }
 

--- a/internal/controller/rootshard/controller.go
+++ b/internal/controller/rootshard/controller.go
@@ -129,8 +129,6 @@ func (r *RootShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		recErr = kerrors.NewAggregate([]error{recErr, err})
 	}
 
-	metrics.RecordObjectMetrics(metrics.RootShardResourceType, &rootShard, rootShard.Status.Conditions)
-
 	return ctrl.Result{}, recErr
 }
 

--- a/internal/controller/shard/controller.go
+++ b/internal/controller/shard/controller.go
@@ -127,8 +127,6 @@ func (r *ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res 
 		recErr = kerrors.NewAggregate([]error{recErr, err})
 	}
 
-	metrics.RecordObjectMetrics(metrics.ShardResourceType, &s, s.Status.Conditions)
-
 	return ctrl.Result{}, recErr
 }
 

--- a/internal/metrics/helpers.go
+++ b/internal/metrics/helpers.go
@@ -28,15 +28,6 @@ const (
 	KubeconfigResourceType  = "kubeconfig"
 )
 
-// RecordObjectMetrics records metrics for the conditions of a Kubernetes object.
-func RecordObjectMetrics(resourceType string, obj metav1.Object, conditions []metav1.Condition) {
-	for _, condition := range conditions {
-		ConditionStatus.
-			WithLabelValues(resourceType, obj.GetName(), obj.GetNamespace(), condition.Type).
-			Set(statusToMetric(condition.Status))
-	}
-}
-
 func statusToMetric(status metav1.ConditionStatus) float64 {
 	switch status {
 	case metav1.ConditionTrue:


### PR DESCRIPTION
## Summary
After every reconciliation, we call RecordObjectMetrics, which would set the *Count metric for the given (namespace,phase) combination to 1. So after reconciling 5 objects, the metric is 1, not 5.

At the same time, the MetricsCollector regularly updates the *Count metrics with the correct values. However it races with the reconcilers, and even if locking were used, I do not understand why the reconcilers would reset the *Count metrics every single time to 1.

Hence this PR removes the updating of the *Count metrics in each reconciliation, and makes the code a bit more readable.

I then also went ahead and removed the last bits of the RecordObjectMetrics function because when an object gets deleted, the metrics would remain forever (well, until the operator is restarted). The MetricsCollector has the right approach (fetch all objects on a schedule, update all the counts at once), so I simply moved the status handling over there. It already has a list of all objects with their full bodies, so why not.

## What Type of PR Is This?
/kind bug

## Release Notes
```release-note
Fix stale and incorrect metric values.
```
