### PR TITLE
Add revision labels to PodTemplates in order to automatically rotate Deployments

### DIFF
--- a/internal/controller/rootshard/controller.go
+++ b/internal/controller/rootshard/controller.go
@@ -18,6 +18,7 @@ package rootshard
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -44,6 +45,7 @@ import (
 	"github.com/kcp-dev/kcp-operator/internal/controller/util"
 	"github.com/kcp-dev/kcp-operator/internal/metrics"
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
+	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
 	"github.com/kcp-dev/kcp-operator/internal/resources"
 	"github.com/kcp-dev/kcp-operator/internal/resources/frontproxy"
 	"github.com/kcp-dev/kcp-operator/internal/resources/rootshard"
@@ -149,6 +151,7 @@ func (r *RootShardReconciler) reconcile(ctx context.Context, rootShard *operator
 	}
 
 	ownerRefWrapper := k8creconciling.OwnerRefWrapper(*metav1.NewControllerRef(rootShard, operatorv1alpha1.SchemeGroupVersion.WithKind("RootShard")))
+	revisionLabels := modifier.RelatedRevisionsLabels(ctx, r.Client)
 
 	issuerReconcilers := []reconciling.NamedIssuerReconcilerFactory{
 		rootshard.RootCAIssuerReconciler(rootShard),
@@ -206,8 +209,11 @@ func (r *RootShardReconciler) reconcile(ctx context.Context, rootShard *operator
 	// Deployment will be scaled to 0 if bundle annotation is present
 	if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{
 		rootshard.DeploymentReconciler(rootShard),
-	}, rootShard.Namespace, r.Client, ownerRefWrapper); err != nil {
-		errs = append(errs, err)
+	}, rootShard.Namespace, r.Client, ownerRefWrapper, revisionLabels); err != nil {
+		// Swallow these errors and instead rely on us watching Secrets and re-reconciling whenever they change.
+		if !errors.Is(err, modifier.ErrMountNotFound) {
+			errs = append(errs, err)
+		}
 	}
 
 	if err := k8creconciling.ReconcileServices(ctx, []k8creconciling.NamedServiceReconcilerFactory{

--- a/internal/reconciling/modifier/revision_labels.go
+++ b/internal/reconciling/modifier/revision_labels.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2026 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modifier
+
+import (
+	"context"
+	"crypto/sha3"
+	"fmt"
+	"maps"
+
+	"k8c.io/reconciler/pkg/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var ErrMountNotFound = fmt.Errorf("mounted Secret or ConfigMap not found")
+
+// RelatedRevisionsLabels scans volume mounts for pod templates for ConfigMaps
+// and Secrets and will then put new labels for these mounts onto the pod template, causing
+// restarts when the volumes changed.
+func RelatedRevisionsLabels(ctx context.Context, client ctrlruntimeclient.Client) reconciling.ObjectModifier {
+	return func(reconciler reconciling.ObjectReconciler) reconciling.ObjectReconciler {
+		return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+			obj, err := reconciler(existing)
+			if err != nil {
+				return obj, err
+			}
+
+			return addRevisionLabelsToObject(ctx, client, obj)
+		}
+	}
+}
+
+func addRevisionLabelsToObject(ctx context.Context, client ctrlruntimeclient.Client, obj ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+	switch asserted := obj.(type) {
+	case *appsv1.Deployment:
+		if err := addRevisionLabelsToPodSpec(ctx, client, asserted.Namespace, &asserted.Spec.Template); err != nil {
+			return nil, fmt.Errorf("failed to determine revision labels: %w", err)
+		}
+
+	case *appsv1.StatefulSet:
+		if err := addRevisionLabelsToPodSpec(ctx, client, asserted.Namespace, &asserted.Spec.Template); err != nil {
+			return nil, fmt.Errorf("failed to determine revision labels: %w", err)
+		}
+
+	case *appsv1.DaemonSet:
+		if err := addRevisionLabelsToPodSpec(ctx, client, asserted.Namespace, &asserted.Spec.Template); err != nil {
+			return nil, fmt.Errorf("failed to determine revision labels: %w", err)
+		}
+
+	default:
+		panic(fmt.Sprintf("RelatedRevisionsLabels modifier used on incompatible type %T", obj))
+	}
+
+	return obj, nil
+}
+
+func addRevisionLabelsToPodSpec(ctx context.Context, client ctrlruntimeclient.Client, namespace string, ps *corev1.PodTemplateSpec) error {
+	allContainers := []corev1.Container{}
+	allContainers = append(allContainers, ps.Spec.InitContainers...)
+	allContainers = append(allContainers, ps.Spec.Containers...)
+
+	revisionLabels, err := getRelatedRevisionLabels(ctx, client, namespace, ps.Spec.Volumes, allContainers)
+	if err != nil {
+		// allow consumers to detect that this error is solely because of missing objects, not because
+		// of broken permissions or anything else
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("%w: %v", ErrMountNotFound, err)
+		}
+
+		return err
+	}
+
+	// Do not directly modify ps.Labels, as it might be shared between multiple places in the object
+	// (think object labels, plus selector labels) and some of these places might be immutable.
+	newLabels := make(map[string]string)
+	if ps.Labels != nil {
+		maps.Copy(newLabels, ps.Labels)
+	}
+
+	maps.Copy(newLabels, revisionLabels)
+	ps.Labels = newLabels
+
+	return nil
+}
+
+func getLabelName(resource, object string) string {
+	// prevent long resource names from creating too long label names
+	hash := fmt.Sprintf("%x", sha3.Sum256([]byte(object)))
+
+	return fmt.Sprintf("operator.kcp.io/%s-%s-rev", resource, hash[:20])
+}
+
+// getRelatedRevisionLabels returns a set of labels for the given volumes/containers,
+// with one label per ConfigMap or Secret, containing the objects' revisions.
+// When used for pod template labels, this will force pods being restarted as soon as one
+// of the secrets/configmaps get updated.
+func getRelatedRevisionLabels(
+	ctx context.Context,
+	client ctrlruntimeclient.Client,
+	namespace string,
+	volumes []corev1.Volume,
+	containers []corev1.Container,
+) (map[string]string, error) {
+	labels := make(map[string]string)
+
+	loadSecret := func(name string, optional bool) error {
+		labelName := getLabelName("secret", name)
+
+		// skip checking the same secret again
+		if _, ok := labels[labelName]; ok {
+			return nil
+		}
+
+		key := types.NamespacedName{Namespace: namespace, Name: name}
+		revision, err := secretRevision(ctx, client, key)
+		if err != nil {
+			if optional && apierrors.IsNotFound(err) {
+				return nil
+			}
+
+			return err
+		}
+
+		labels[labelName] = revision
+
+		return nil
+	}
+
+	loadConfigMap := func(name string, optional bool) error {
+		labelName := getLabelName("configmap", name)
+
+		// skip checking the same ConfigMap again
+		if _, ok := labels[labelName]; ok {
+			return nil
+		}
+
+		key := types.NamespacedName{Namespace: namespace, Name: name}
+		revision, err := configMapRevision(ctx, client, key)
+		if err != nil {
+			if optional && apierrors.IsNotFound(err) {
+				return nil
+			}
+
+			return err
+		}
+
+		labels[labelName] = revision
+
+		return nil
+	}
+
+	for _, v := range volumes {
+		if v.Secret != nil {
+			if err := loadSecret(v.Secret.SecretName, false); err != nil {
+				return nil, err
+			}
+		}
+
+		if v.ConfigMap != nil {
+			if err := loadConfigMap(v.ConfigMap.Name, false); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	for _, c := range containers {
+		for _, e := range c.Env {
+			if source := e.ValueFrom; source != nil {
+				if cm := source.ConfigMapKeyRef; cm != nil {
+					if err := loadConfigMap(cm.Name, cm.Optional != nil && *cm.Optional); err != nil {
+						return nil, err
+					}
+				}
+
+				if sec := source.SecretKeyRef; sec != nil {
+					if err := loadSecret(sec.Name, sec.Optional != nil && *sec.Optional); err != nil {
+						return nil, err
+					}
+				}
+			}
+		}
+
+		for _, e := range c.EnvFrom {
+			if cm := e.ConfigMapRef; cm != nil {
+				if err := loadConfigMap(cm.Name, cm.Optional != nil && *cm.Optional); err != nil {
+					return nil, err
+				}
+			}
+
+			if sec := e.SecretRef; sec != nil {
+				if err := loadSecret(sec.Name, sec.Optional != nil && *sec.Optional); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	return labels, nil
+}
+
+// secretRevision returns the resource version of the Secret specified by name.
+func secretRevision(ctx context.Context, client ctrlruntimeclient.Client, key types.NamespacedName) (string, error) {
+	secret := &corev1.Secret{}
+	err := client.Get(ctx, key, secret)
+
+	return secret.ResourceVersion, err
+}
+
+// configMapRevision returns the resource version of the ConfigMap specified by name.
+func configMapRevision(ctx context.Context, client ctrlruntimeclient.Client, key types.NamespacedName) (string, error) {
+	cm := &corev1.ConfigMap{}
+	err := client.Get(ctx, key, cm)
+
+	return cm.ResourceVersion, err
+}


### PR DESCRIPTION
## Summary
This PR adds "revision labels" to the PodTemplates in the Deployments managed by the kcp-operator: One label for each mounted Secret/ConfigMap, containing those objects' resource version.

The usecase is to automatically rotate Deployments whenever Secrets change, which happens every time a Certificate is renewed or changed (like a new organization being added).

The new middleware will return an error if a mounted object does not exist yet, so while a new Shard or RootShard or FrontProxy is being rolled out, a lot of errors would happen until all Certificates have been issued by cert-manager. To avoid spamming the logs, the operator swallows these errors and relies on it watching the Secrets to reconcile again later. The other alternative would be to skip labels for non-existent mounted Secrets, but this will just lead to lots of pointless pods being created (pointless because even though the operator ignores the missing Secrets, Kubernetes cannot and so the Pods would all be in ContainerCreating). This feels worse than holding off the Deployment creation.

## What Type of PR Is This?
/kind feature

## Release Notes
```release-note
Add revision labels to PodTemplates in order to automatically rotate Deployments whenever a mounted Secret changes.
```
