### PR TITLE
Extend sample manifests with explanation for ServiceAccount support

### DIFF
--- a/config/samples/operator.kcp.io_v1alpha1_frontproxy.yaml
+++ b/config/samples/operator.kcp.io_v1alpha1_frontproxy.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   auth:
     serviceAccount:
+      # if you want controllers to access particular workspaces using service accounts
+      # serviceAccounts must be enabled, on all shards and the front-proxy.
       enabled: true
   rootShard:
     ref:
@@ -18,6 +20,7 @@ spec:
       type: LoadBalancer
       # hard code a specific cluster IP, e.g. for a kind setup.
       clusterIP: 10.96.100.100
+
   certificateTemplates:
     server:
       spec:

--- a/config/samples/operator.kcp.io_v1alpha1_rootshard.yaml
+++ b/config/samples/operator.kcp.io_v1alpha1_rootshard.yaml
@@ -34,6 +34,12 @@ spec:
     spec:
       type: LoadBalancer
 
+  auth:
+    serviceAccount:
+      # if you want controllers to access particular workspaces using service accounts
+      # serviceAccounts must be enabled, on all shards and the front-proxy.
+      enabled: true
+
   cache:
     embedded:
       enabled: true

--- a/config/samples/operator.kcp.io_v1alpha1_shard.yaml
+++ b/config/samples/operator.kcp.io_v1alpha1_shard.yaml
@@ -12,6 +12,11 @@ spec:
   rootShard:
     ref:
       name: shard-sample
+  auth:
+    serviceAccount:
+      # if you want controllers to access particular workspaces using service accounts
+      # serviceAccounts must be enabled, on all shards and the front-proxy.
+      enabled: true
   logLevel:
     verbosityLevel: 4
   deploymentTemplate:


### PR DESCRIPTION
<!--

-->

## Summary

To support workspace access using Service Accounts, the front-proxy as well as the shards
must explicitly be configured to enable this.
The sample manifests are extended with those settings and a short explanation.

## What Type of PR Is This?
/kind documentation
<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
