### PR TITLE
docs: update local setup with etcd helm chart

### DIFF
--- a/docs/content/contributing/local-setup.md
+++ b/docs/content/contributing/local-setup.md
@@ -37,8 +37,8 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 Set up two etcd instances, one for the root shard and one for a supplementary shard:
 
 ```sh
-helm install etcd oci://registry-1.docker.io/bitnamicharts/etcd --set auth.rbac.enabled=false --set auth.rbac.create=false
-helm install etcd-shard oci://registry-1.docker.io/bitnamicharts/etcd --set auth.rbac.enabled=false --set auth.rbac.create=false
+helm install etcd ./hack/ci/testdata/etcd
+helm install etcd-shard ./hack/ci/testdata/etcd
 ```
 
 Create a "self-signed" cert-manager issuer:


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Our docs in contributing/local-setup.md have outdated info on etcd deployment: bitnami no longer distributes etcd. This PR updates it, referring to kcp-operator's tiny etcd helm chart.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind documentation

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
