### PR TITLE
Guard metrics collector with mutex

### DIFF
--- a/hack/run-e2e-tests.sh
+++ b/hack/run-e2e-tests.sh
@@ -161,6 +161,7 @@ echo "Running e2e tests..."
 
 export HELM_BINARY="$HELM"
 export ETCD_HELM_CHART="$(realpath hack/ci/testdata/etcd)"
+export KCP_RELEASE="${KCP_TAG:-}"
 
 WHAT="${WHAT:-./test/e2e/...}"
 TEST_ARGS="${TEST_ARGS:--timeout 2h -v}"

--- a/hack/run-e2e-tests.sh
+++ b/hack/run-e2e-tests.sh
@@ -161,7 +161,6 @@ echo "Running e2e tests..."
 
 export HELM_BINARY="$HELM"
 export ETCD_HELM_CHART="$(realpath hack/ci/testdata/etcd)"
-export KCP_RELEASE="${KCP_TAG:-}"
 
 WHAT="${WHAT:-./test/e2e/...}"
 TEST_ARGS="${TEST_ARGS:--timeout 2h -v}"

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -18,12 +18,14 @@ package metrics
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -32,6 +34,7 @@ const (
 
 type MetricsCollector struct {
 	client ctrlruntimeclient.Client
+	mu     sync.RWMutex
 }
 
 func NewMetricsCollector(client ctrlruntimeclient.Client) *MetricsCollector {
@@ -64,6 +67,9 @@ func recordConditionStatuses(resourceType, name, namespace string, conditions []
 }
 
 func (mc *MetricsCollector) updateObjectCounts(ctx context.Context) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
 	ConditionStatus.Reset()
 	mc.updateRootShardCounts(ctx)
 	mc.updateShardCounts(ctx)
@@ -214,4 +220,16 @@ func (mc *MetricsCollector) updateVirtualWorkspaceCounts(ctx context.Context) {
 	for namespace, count := range namespaceCounts {
 		VirtualWorkspaceCount.WithLabelValues(namespace).Set(float64(count))
 	}
+}
+
+func (mc *MetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	ConditionStatus.Collect(ch)
+	RootShardCount.Collect(ch)
+	ShardCount.Collect(ch)
+	FrontProxyCount.Collect(ch)
+	CacheServerCount.Collect(ch)
+	KubeconfigCount.Collect(ch)
 }

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -217,6 +217,7 @@ func (mc *MetricsCollector) updateKubeconfigCounts(ctx context.Context) {
 	}
 }
 
+// updateVirtualWorkspaceCounts updates metrics for VirtualWorkspace resources.
 func (mc *MetricsCollector) updateVirtualWorkspaceCounts(ctx context.Context) {
 	var virtualWorkspaces operatorv1alpha1.VirtualWorkspaceList
 	if err := mc.client.List(ctx, &virtualWorkspaces); err != nil {
@@ -235,7 +236,7 @@ func (mc *MetricsCollector) updateVirtualWorkspaceCounts(ctx context.Context) {
 	}
 }
 
-// Collect safely reads metrics.
+// Collect safely exposes a consistent snapshot of metrics to Prometheus.
 func (mc *MetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	mc.mu.RLock()
 	defer mc.mu.RUnlock()

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -21,31 +21,37 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
+	// UnknownPhase is used when the phase of a resource is empty.
 	UnknownPhase = "Unknown"
 )
 
+// MetricsCollector collects metrics for kcp-operator resources.
 type MetricsCollector struct {
 	client ctrlruntimeclient.Client
 	mu     sync.RWMutex
 }
 
+// NewMetricsCollector creates a new MetricsCollector.
 func NewMetricsCollector(client ctrlruntimeclient.Client) *MetricsCollector {
 	return &MetricsCollector{
 		client: client,
 	}
 }
 
+// Start begins periodic metrics updates every 30 seconds until ctx is canceled.
 func (mc *MetricsCollector) Start(ctx context.Context) {
 	ticker := time.NewTicker(30 * time.Second)
 
+	// Initial update
 	mc.updateObjectCounts(ctx)
 
 	for {
@@ -58,6 +64,7 @@ func (mc *MetricsCollector) Start(ctx context.Context) {
 	}
 }
 
+// recordConditionStatuses sets Prometheus metrics for resource conditions.
 func recordConditionStatuses(resourceType, name, namespace string, conditions []metav1.Condition) {
 	for _, condition := range conditions {
 		ConditionStatus.
@@ -66,6 +73,7 @@ func recordConditionStatuses(resourceType, name, namespace string, conditions []
 	}
 }
 
+// updateObjectCounts resets and repopulates all resource metrics.
 func (mc *MetricsCollector) updateObjectCounts(ctx context.Context) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
@@ -79,6 +87,7 @@ func (mc *MetricsCollector) updateObjectCounts(ctx context.Context) {
 	mc.updateVirtualWorkspaceCounts(ctx)
 }
 
+// updateRootSharedCounts updates metrics for RootShard resources.
 func (mc *MetricsCollector) updateRootShardCounts(ctx context.Context) {
 	var rootShards operatorv1alpha1.RootShardList
 	if err := mc.client.List(ctx, &rootShards); err != nil {
@@ -108,6 +117,7 @@ func (mc *MetricsCollector) updateRootShardCounts(ctx context.Context) {
 	}
 }
 
+// updateShardCounts updates metrics for Shard resources.
 func (mc *MetricsCollector) updateShardCounts(ctx context.Context) {
 	var shards operatorv1alpha1.ShardList
 	if err := mc.client.List(ctx, &shards); err != nil {
@@ -137,6 +147,7 @@ func (mc *MetricsCollector) updateShardCounts(ctx context.Context) {
 	}
 }
 
+// updateFrontProxyCounts updates metrics for FrontProxy resources.
 func (mc *MetricsCollector) updateFrontProxyCounts(ctx context.Context) {
 	var frontProxies operatorv1alpha1.FrontProxyList
 	if err := mc.client.List(ctx, &frontProxies); err != nil {
@@ -166,6 +177,7 @@ func (mc *MetricsCollector) updateFrontProxyCounts(ctx context.Context) {
 	}
 }
 
+// updateCacheServerCounts updates metrics for CacheServer resources.
 func (mc *MetricsCollector) updateCacheServerCounts(ctx context.Context) {
 	var cacheServers operatorv1alpha1.CacheServerList
 	if err := mc.client.List(ctx, &cacheServers); err != nil {
@@ -184,6 +196,7 @@ func (mc *MetricsCollector) updateCacheServerCounts(ctx context.Context) {
 	}
 }
 
+// updateKubeconfigCounts updates metrics for Kubeconfig resources.
 func (mc *MetricsCollector) updateKubeconfigCounts(ctx context.Context) {
 	var kubeconfigs operatorv1alpha1.KubeconfigList
 	if err := mc.client.List(ctx, &kubeconfigs); err != nil {
@@ -222,6 +235,7 @@ func (mc *MetricsCollector) updateVirtualWorkspaceCounts(ctx context.Context) {
 	}
 }
 
+// Collect safely reads metrics.
 func (mc *MetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	mc.mu.RLock()
 	defer mc.mu.RUnlock()


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Make `MetricsCollector` thread-safe and prevent metric disappearance during Prometheus scrapes by adding a `sync.RWMutex` and a `Collect()` method.

Note: Also added `defer ticker.Stop()` and commenting.

## What Type of PR Is This?

/kind bug
/kind cleanup
/kind documentation

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #160

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
MetricsCollector is now thread-safe.
```
