### PR TITLE
upgrade to Go 1.26.2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,23 @@
 <!--
 
 Thanks for creating a pull request!
-If this is your first time, please make sure to review CONTRIBUTING.MD.
+If this is your first time, please make sure to review CONTRIBUTING.md.
 
 -->
 
 ## Summary
+<!--
+Please provide a description that explains *why* your PR is changing something
+in the codebase, and focus less on what *what* you're changing. The following are
+good questions to ask yourself when writing the PR summary:
+
+* What are the problems you are trying to solve?
+* What assumptions did you make when implementing your changes?
+* Which workflows will be affected/improved by your change?
+-->
 
 ## What Type of PR Is This?
-
 <!--
-
 Add one of the following kinds:
 /kind bug
 /kind chore
@@ -24,19 +31,16 @@ Optionally add one or more of the following kinds if applicable:
 /kind failing-test
 /kind flake
 /kind regression
-
 -->
 
 ## Related Issue(s)
-
 Fixes #
 
 ## Release Notes
-
 <!--
-Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
+Please add a release note in the block below.
+Leave NONE only if no user-facing changes are in this PR.
 -->
-
 ```release-note
 NONE
 ```

--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # tag=v6.1.0
         with:
-          go-version: v1.24.11
+          go-version: v1.26.2
           cache: true
 
       - name: Setup Python

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
           command:
             - make
             - verify
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
           command:
             - make
             - lint
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
           command:
             - make
             - test
@@ -86,7 +86,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -109,7 +109,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -132,7 +132,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
           command:
             - hack/ci/run-e2e-tests.sh
           resources:
@@ -152,7 +152,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.11 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
This bumps us 2 Go versions ahead and also tweaks the PR template a bit. I want to make sure that folks who use AI still make sure to explain _WHYYYY_ they want to change things. The WHY is where AI usually struggles to generate a good explanation.

## What Type of PR Is This?
/kind chore

## Release Notes
```release-note
Update to Go 1.26.2
```
