### PR TITLE
[release-0.6] update to Go 1.24.13

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # tag=v6.1.0
         with:
-          go-version: v1.24.11
+          go-version: v1.24.13
           cache: true
 
       - name: Setup Python

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.13-1
           command:
             - make
             - verify
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.13-1
           command:
             - make
             - lint
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.13-1
           command:
             - make
             - test
@@ -86,7 +86,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.13-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -109,7 +109,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.13-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -132,7 +132,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.13-1
           command:
             - hack/ci/run-e2e-tests.sh
           resources:
@@ -152,7 +152,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.13-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.11 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.13 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
Bumps to the latest 1.24.x Go version.

## What Type of PR Is This?
/kind chore

## Release Notes
```release-note
Update to Go 1.24.13.
```
