### PR TITLE
restore kcp 0.28 tests

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -159,6 +159,8 @@ presubmits:
           env:
             - name: KCP_TAG
               value: main
+            - name: KCP_RELEASE
+              value: '0.31'
           resources:
             requests:
               memory: 8Gi

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -77,6 +77,29 @@ presubmits:
               memory: 8Gi
               cpu: 4
 
+  - name: pull-kcp-operator-test-e2e-0.28
+    decorate: true
+    run_if_changed: "(Dockerfile|Makefile|.prow.yaml|go.mod|go.sum|cmd|internal|sdk|hack|test|config)"
+    optional: false
+    clone_uri: "https://github.com/kcp-dev/kcp-operator"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
+          command:
+            - hack/ci/run-e2e-tests.sh
+          env:
+            - name: KCP_TAG
+              value: release-0.28
+          resources:
+            requests:
+              memory: 8Gi
+              cpu: 4
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+
   - name: pull-kcp-operator-test-e2e-0.29
     decorate: true
     run_if_changed: "(Dockerfile|Makefile|.prow.yaml|go.mod|go.sum|cmd|internal|sdk|hack|test|config)"
@@ -100,29 +123,7 @@ presubmits:
           securityContext:
             privileged: true
 
-  - name: pull-kcp-operator-test-e2e-0.30
-    decorate: true
-    run_if_changed: "(Dockerfile|Makefile|.prow.yaml|go.mod|go.sum|cmd|internal|sdk|hack|test|config)"
-    optional: false
-    clone_uri: "https://github.com/kcp-dev/kcp-operator"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
-          command:
-            - hack/ci/run-e2e-tests.sh
-          env:
-            - name: KCP_TAG
-              value: release-0.30
-          resources:
-            requests:
-              memory: 8Gi
-              cpu: 4
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-
+  # default is currently kcp 0.30
   - name: pull-kcp-operator-test-e2e-default
     decorate: true
     run_if_changed: "(Dockerfile|Makefile|.prow.yaml|go.mod|go.sum|cmd|internal|sdk|hack|test|config)"

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 replace github.com/kcp-dev/kcp-operator/sdk => ./sdk
 
 require (
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/cert-manager/cert-manager v1.18.5
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/zapr v1.3.0
@@ -30,7 +31,6 @@ require (
 
 require (
 	cel.dev/expr v0.25.1 // indirect
-	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/hack/ci/run-e2e-tests.sh
+++ b/hack/ci/run-e2e-tests.sh
@@ -19,29 +19,48 @@ set -euo pipefail
 cd "$(dirname "$0")/../.."
 source hack/lib.sh
 
-# KCP_TAG (when coming from .prow.yaml) is set to release-* branch name.
-# We stash it into KCP_RELEASE because KCP_TAG is overridden later to a specific
-# git hash of that branch.
-export KCP_RELEASE="${KCP_TAG:-}"
+# start docker so we can run kind
+start_docker_daemon_ci
 
 # For periodics especially it's important that we output what versions exactly
 # we're testing against.
+PRELOAD_IMAGE=
+
 if [ -n "${KCP_TAG:-}" ]; then
   # resolve what looks like branch names
   if [[ "$KCP_TAG" == main ]] || [[ "$KCP_TAG" =~ ^release- ]]; then
-    echo "Resolving kcp $KCP_TAG ..."
+    if [[ "$KCP_TAG" == main ]]; then
+      # rely on a KCP_RELEASE env in the Prowjob
+      KCP_TAG_ALIAS="v$KCP_RELEASE.999"
+    else
+      KCP_TAG_ALIAS="v$(echo "$KCP_TAG" | sed -E 's/release-//g').999"
+    fi
+
+    echo "Resolving kcp $KCP_TAG (as $KCP_TAG_ALIAS)..."
 
     tmpdir="$(mktemp -d)"
     here="$(pwd)"
 
     cd "$tmpdir"
     git clone --quiet --depth 1 --branch "$KCP_TAG" --single-branch https://github.com/kcp-dev/kcp .
-    KCP_TAG="$(git rev-parse HEAD)"
+    gitHead="$(git rev-parse HEAD)"
     cd "$here"
     rm -rf "$tmpdir"
 
     # kcp's containers are tagged with the first 9 characters of the Git hash
-    KCP_TAG="${KCP_TAG:0:9}"
+    ORIGINAL_TAG="${gitHead:0:9}"
+
+    echo "Going to use kcp image $ORIGINAL_TAG as $KCP_TAG_ALIAS."
+
+    # Due to the process above, we might now run the tests against "kcp:d6ab2dc"
+    # or whatever random hash might be the most recent build. This interferes with
+    # the operator's version detection. To work around this, we pull the image first,
+    # retag it with a dummy version, load it into kind and then use that image.
+    KCP_TAG="$KCP_TAG_ALIAS"
+    ORIGINAL_IMAGE="ghcr.io/kcp-dev/kcp:$ORIGINAL_TAG"
+    PRELOAD_IMAGE="ghcr.io/kcp-dev/kcp:$KCP_TAG"
+    docker pull "$ORIGINAL_IMAGE"
+    docker tag "$ORIGINAL_IMAGE" "$PRELOAD_IMAGE"
   fi
 
   echo "kcp image tag.......: $KCP_TAG"
@@ -57,9 +76,6 @@ export IMAGE_TAG=local
 echo "Building container images..."
 ARCHITECTURES=arm64 DRY_RUN=yes ./hack/ci/build-image.sh
 
-# start docker so we can run kind
-start_docker_daemon_ci
-
 # create a local kind cluster
 KIND_CLUSTER_NAME=e2e
 
@@ -70,6 +86,12 @@ export KUBECONFIG=$(mktemp)
 echo "Creating kind cluster $KIND_CLUSTER_NAME..."
 create_kind_cluster "$KIND_CLUSTER_NAME" kindest/node:v1.32.2
 chmod 600 "$KUBECONFIG"
+
+# preload the custom kcp image, if requested
+if [[ -n "$PRELOAD_IMAGE" ]]; then
+  echo "Preloading kcp image $PRELOAD_IMAGE into kind cluster..."
+  retry_linear 1 5 kind load docker-image "$PRELOAD_IMAGE" --name "$KIND_CLUSTER_NAME"
+fi
 
 # apply kernel limits job first and wait for completion
 echo "Applying kernel limits job…"

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -14,6 +14,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+retry_linear() {
+  delay=$1
+  retries=$2
+  shift
+  shift
+
+  count=0
+  until "$@"; do
+    rc=$?
+    count=$((count + 1))
+    if [ $count -lt "$retries" ]; then
+      echo "[$count/$retries] Command returned $rc, retrying…"
+      sleep $delay
+    else
+      echo "Command returned $rc, no more retries left."
+      return $rc
+    fi
+  done
+
+  return 0
+}
+
 start_docker_daemon_ci() {
   # DOCKER_REGISTRY_MIRROR_ADDR is injected via Prow preset;
   # MTU improves the docker-in-docker networking;

--- a/hack/run-e2e-tests.sh
+++ b/hack/run-e2e-tests.sh
@@ -16,6 +16,9 @@
 
 set -euo pipefail
 
+cd $(dirname $0)/..
+source hack/lib.sh
+
 export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-e2e}"
 DATA_DIR=".e2e-$KIND_CLUSTER_NAME"
 OPERATOR_PID=0
@@ -69,6 +72,48 @@ fi
 
 echo "Kubeconfig is in $KUBECONFIG."
 
+if [ -n "${KCP_TAG:-}" ]; then
+  # resolve what looks like branch names
+  if [[ "$KCP_TAG" == main ]] || [[ "$KCP_TAG" =~ ^release- ]]; then
+    if [[ "$KCP_TAG" == main ]]; then
+      # rely on a KCP_RELEASE env in the Prowjob
+      KCP_TAG_ALIAS="v$KCP_RELEASE.999"
+    else
+      KCP_TAG_ALIAS="v$(echo "$KCP_TAG" | sed -E 's/release-//g').999"
+    fi
+
+    echo "Resolving kcp $KCP_TAG (as $KCP_TAG_ALIAS)..."
+
+    tmpdir="$(mktemp -d)"
+    here="$(pwd)"
+
+    cd "$tmpdir"
+    git clone --quiet --depth 1 --branch "$KCP_TAG" --single-branch https://github.com/kcp-dev/kcp .
+    gitHead="$(git rev-parse HEAD)"
+    cd "$here"
+    rm -rf "$tmpdir"
+
+    # kcp's containers are tagged with the first 9 characters of the Git hash
+    ORIGINAL_TAG="${gitHead:0:9}"
+
+    echo "Going to use kcp image $ORIGINAL_TAG as $KCP_TAG_ALIAS."
+
+    # Due to the process above, we might now run the tests against "kcp:d6ab2dc"
+    # or whatever random hash might be the most recent build. This interferes with
+    # the operator's version detection. To work around this, we pull the image first,
+    # retag it with a dummy version, load it into kind and then use that image.
+    KCP_TAG="$KCP_TAG_ALIAS"
+    ORIGINAL_IMAGE="ghcr.io/kcp-dev/kcp:$ORIGINAL_TAG"
+    PRELOAD_IMAGE="ghcr.io/kcp-dev/kcp:$KCP_TAG"
+    docker pull "$ORIGINAL_IMAGE"
+    docker tag "$ORIGINAL_IMAGE" "$PRELOAD_IMAGE"
+
+    retry_linear 1 5 kind load docker-image "$PRELOAD_IMAGE" --name "$KIND_CLUSTER_NAME"
+  fi
+
+  echo "kcp image tag: $KCP_TAG"
+fi
+
 KUBECTL="$(UGET_PRINT_PATH=absolute make --no-print-directory install-kubectl)"
 KUSTOMIZE="$(UGET_PRINT_PATH=absolute make --no-print-directory install-kustomize)"
 HELM="$(UGET_PRINT_PATH=absolute make --no-print-directory install-helm)"
@@ -116,7 +161,6 @@ echo "Running e2e tests..."
 
 export HELM_BINARY="$HELM"
 export ETCD_HELM_CHART="$(realpath hack/ci/testdata/etcd)"
-export KCP_RELEASE="${KCP_TAG:-}"
 
 WHAT="${WHAT:-./test/e2e/...}"
 TEST_ARGS="${TEST_ARGS:--timeout 2h -v}"

--- a/internal/resources/cacheserver/deployment.go
+++ b/internal/resources/cacheserver/deployment.go
@@ -272,7 +272,7 @@ func hasAuthenticatedCache(version *semver.Version) bool {
 
 	// Only include client-ca for kcp >= 0.29; 0.28 users will have to ensure their
 	// tags parse as 0.28 to ensure compatibility with recent kcp-operators.
-	constraint, _ := semver.NewConstraint("~0.29.2 || ~0.30.2")
+	constraint, _ := semver.NewConstraint("~0.29.2 || ~0.30.2 || >=0.31.0")
 
 	return constraint.Check(version)
 }

--- a/internal/resources/cacheserver/deployment.go
+++ b/internal/resources/cacheserver/deployment.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"k8c.io/reconciler/pkg/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -91,11 +92,11 @@ func DeploymentReconciler(server *operatorv1alpha1.CacheServer) reconciling.Name
 			dep.Spec.Template.SetLabels(labels)
 
 			// TODO: Why do we discard the imagePullSecrets?
-			image, _ := resources.GetImageSettings(server.Spec.Image)
+			image, _, version := resources.GetImageSettings(server.Spec.Image)
 
 			volumes, volumeMounts := getVolumeMounts(server)
 
-			for _, sm := range getSecretMounts(server) {
+			for _, sm := range getSecretMounts(server, version) {
 				v, vm := sm.Build()
 				volumes = append(volumes, v)
 				volumeMounts = append(volumeMounts, vm)
@@ -105,7 +106,7 @@ func DeploymentReconciler(server *operatorv1alpha1.CacheServer) reconciling.Name
 				Name:         ServerContainerName,
 				Image:        image,
 				Command:      []string{"/cache-server"},
-				Args:         getArgs(server),
+				Args:         getArgs(server, version),
 				VolumeMounts: volumeMounts,
 				Resources:    defaultResourceRequirements,
 				SecurityContext: &corev1.SecurityContext{
@@ -197,15 +198,18 @@ func getVolumeMounts(server *operatorv1alpha1.CacheServer) (volumes []corev1.Vol
 	return
 }
 
-func getArgs(server *operatorv1alpha1.CacheServer) []string {
+func getArgs(server *operatorv1alpha1.CacheServer, version *semver.Version) []string {
 	args := []string{
 		// Certificate flags (server, service account signing).
 		fmt.Sprintf("--tls-cert-file=%s/tls.crt", getCertificateMountPath(operatorv1alpha1.ServerCertificate)),
 		fmt.Sprintf("--tls-private-key-file=%s/tls.key", getCertificateMountPath(operatorv1alpha1.ServerCertificate)),
-		// Client CA for authenticating clients connecting to the cache server.
-		fmt.Sprintf("--client-ca-file=%s/tls.crt", getCAMountPath(operatorv1alpha1.RootCA)),
 		// Configure (lack of) persistence.
 		"--root-directory=",
+	}
+
+	if hasAuthenticatedCache(version) {
+		// Client CA for authenticating clients connecting to the cache server.
+		args = append(args, fmt.Sprintf("--client-ca-file=%s/tls.crt", getCAMountPath(operatorv1alpha1.RootCA)))
 	}
 
 	if server.Spec.Etcd == nil {
@@ -232,18 +236,21 @@ func getArgs(server *operatorv1alpha1.CacheServer) []string {
 	return args
 }
 
-func getSecretMounts(server *operatorv1alpha1.CacheServer) []utils.SecretMount {
+func getSecretMounts(server *operatorv1alpha1.CacheServer, version *semver.Version) []utils.SecretMount {
 	secretMounts := []utils.SecretMount{
 		{
 			VolumeName: "serving-cert",
 			SecretName: resources.GetCacheServerCertificateName(server, operatorv1alpha1.ServerCertificate),
 			MountPath:  getCertificateMountPath(operatorv1alpha1.ServerCertificate),
 		},
-		{
+	}
+
+	if hasAuthenticatedCache(version) {
+		secretMounts = append(secretMounts, utils.SecretMount{
 			VolumeName: "client-ca",
 			SecretName: resources.GetCacheServerCAName(server.Name, operatorv1alpha1.RootCA),
 			MountPath:  getCAMountPath(operatorv1alpha1.RootCA),
-		},
+		})
 	}
 
 	if server.Spec.Etcd != nil && server.Spec.Etcd.TLSConfig != nil {
@@ -255,4 +262,17 @@ func getSecretMounts(server *operatorv1alpha1.CacheServer) []utils.SecretMount {
 	}
 
 	return secretMounts
+}
+
+func hasAuthenticatedCache(version *semver.Version) bool {
+	if version == nil {
+		// If we can't parse the version, assume the best and include the client CA.
+		return true
+	}
+
+	// Only include client-ca for kcp >= 0.29; 0.28 users will have to ensure their
+	// tags parse as 0.28 to ensure compatibility with recent kcp-operators.
+	constraint, _ := semver.NewConstraint("~0.29.2 || ~0.30.2")
+
+	return constraint.Check(version)
 }

--- a/internal/resources/frontproxy/deployment.go
+++ b/internal/resources/frontproxy/deployment.go
@@ -69,7 +69,7 @@ func (r *reconciler) deploymentReconciler() reconciling.NamedDeploymentReconcile
 			}
 			dep.Spec.Template.SetLabels(r.resourceLabels)
 
-			image, _ := resources.GetImageSettings(imageSpec)
+			image, _, _ := resources.GetImageSettings(imageSpec)
 			args := r.getArgs()
 
 			container := corev1.Container{

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -26,7 +26,12 @@ import (
 
 const (
 	ImageRepository = "ghcr.io/kcp-dev/kcp"
-	ImageTag        = "v0.30.3"
+
+	// ImageTag is the default tag to be used for any kcp component.
+	//
+	// When changing this to a new minor version, you must also update
+	// the .prow.yaml accordingly and shift the jobs.
+	ImageTag = "v0.30.3"
 
 	appNameLabel      = "app.kubernetes.io/name"
 	appInstanceLabel  = "app.kubernetes.io/instance"

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"fmt"
 
+	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
 
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
@@ -62,7 +63,7 @@ const (
 	defaultClusterDomain = "cluster.local"
 )
 
-func GetImageSettings(imageSpec *operatorv1alpha1.ImageSpec) (string, []corev1.LocalObjectReference) {
+func GetImageSettings(imageSpec *operatorv1alpha1.ImageSpec) (string, []corev1.LocalObjectReference, *semver.Version) {
 	repository := ImageRepository
 	if imageSpec != nil && imageSpec.Repository != "" {
 		repository = imageSpec.Repository
@@ -78,7 +79,10 @@ func GetImageSettings(imageSpec *operatorv1alpha1.ImageSpec) (string, []corev1.L
 		imagePullSecrets = imageSpec.ImagePullSecrets
 	}
 
-	return fmt.Sprintf("%s:%s", repository, tag), imagePullSecrets
+	// try to detect the kcp version, but accept that this might not work for custom image tags
+	version, _ := semver.NewVersion(tag)
+
+	return fmt.Sprintf("%s:%s", repository, tag), imagePullSecrets, version
 }
 
 func GetRootShardDeploymentName(r *operatorv1alpha1.RootShard) string {

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
+
 	corev1 "k8s.io/api/core/v1"
 
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -26,10 +26,10 @@ import (
 
 func TestGetImageSettings(t *testing.T) {
 	tests := []struct {
-		name              string
-		imageSpec         *operatorv1alpha1.ImageSpec
-		expectedImage     string
-		expectedVersion   string // "major.minor" or empty if unparseable
+		name            string
+		imageSpec       *operatorv1alpha1.ImageSpec
+		expectedImage   string
+		expectedVersion string // "major.minor" or empty if unparseable
 	}{
 		{
 			name:            "default settings",

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+func TestGetImageSettings(t *testing.T) {
+	tests := []struct {
+		name              string
+		imageSpec         *operatorv1alpha1.ImageSpec
+		expectedImage     string
+		expectedVersion   string // "major.minor" or empty if unparseable
+	}{
+		{
+			name:            "default settings",
+			imageSpec:       nil,
+			expectedImage:   "ghcr.io/kcp-dev/kcp:v0.30.3",
+			expectedVersion: "0.30",
+		},
+		{
+			name: "custom tag with valid semver",
+			imageSpec: &operatorv1alpha1.ImageSpec{
+				Tag: "v0.28.1",
+			},
+			expectedImage:   "ghcr.io/kcp-dev/kcp:v0.28.1",
+			expectedVersion: "0.28",
+		},
+		{
+			name: "custom tag with invalid semver",
+			imageSpec: &operatorv1alpha1.ImageSpec{
+				Tag: "latest",
+			},
+			expectedImage:   "ghcr.io/kcp-dev/kcp:latest",
+			expectedVersion: "",
+		},
+		{
+			name: "custom repository and tag",
+			imageSpec: &operatorv1alpha1.ImageSpec{
+				Repository: "custom.registry/kcp",
+				Tag:        "v0.29.0",
+			},
+			expectedImage:   "custom.registry/kcp:v0.29.0",
+			expectedVersion: "0.29",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			image, _, version := GetImageSettings(tt.imageSpec)
+			if image != tt.expectedImage {
+				t.Errorf("expected image %q, got %q", tt.expectedImage, image)
+			}
+
+			if version != nil {
+				v, _ := semver.NewVersion(tt.expectedVersion)
+				if v == nil || version.Major() != v.Major() || version.Minor() != v.Minor() {
+					t.Errorf("expected version %q, got %d.%d", tt.expectedVersion, version.Major(), version.Minor())
+				}
+			} else if tt.expectedVersion != "" {
+				t.Errorf("expected version %q, got nil", tt.expectedVersion)
+			}
+		})
+	}
+}

--- a/internal/resources/utils/shard.go
+++ b/internal/resources/utils/shard.go
@@ -140,7 +140,7 @@ func ApplyCommonShardConfig(deployment *appsv1.Deployment, spec *operatorv1alpha
 	}
 
 	// set container image
-	image, _ := resources.GetImageSettings(spec.Image)
+	image, _, _ := resources.GetImageSettings(spec.Image)
 	container.Image = image
 
 	deployment.Spec.Template.Spec.Containers[0] = container

--- a/internal/resources/virtualworkspace/deployment.go
+++ b/internal/resources/virtualworkspace/deployment.go
@@ -182,7 +182,7 @@ func DeploymentReconciler(vw *operatorv1alpha1.VirtualWorkspace, rootShard *oper
 				volumeMounts = append(volumeMounts, vm)
 			}
 
-			image, _ := resources.GetImageSettings(vw.Spec.Image)
+			image, _, _ := resources.GetImageSettings(vw.Spec.Image)
 
 			container := corev1.Container{
 				Name:         ServerContainerName,

--- a/test/e2e/cacheserver/cacheserver_test.go
+++ b/test/e2e/cacheserver/cacheserver_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	"github.com/kcp-dev/logicalcluster/v3"
 
@@ -94,10 +95,7 @@ func TestCacheWithRootShard(t *testing.T) {
 }
 
 func TestCacheWithExternalEtcdAndRootShard(t *testing.T) {
-	switch utils.GetKcpRelease() {
-	// We skip release "" because it currently points to kcp 0.30 which
-	// doesn't currently support cache-server with an external etcd cluster.
-	case "release-0.29", "release-0.30", "": // TODO(gman0): remove the empty ("") kcp release!
+	if utils.GetKcpRelease().LessThan(semver.MustParse("0.31")) {
 		t.Skip("running external etcd with cache-server is only supported with kcp >=0.31")
 		return
 	}

--- a/test/e2e/virtualworkspaces/virtualworkspaces_test.go
+++ b/test/e2e/virtualworkspaces/virtualworkspaces_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	"github.com/kcp-dev/logicalcluster/v3"
 	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
@@ -47,7 +48,7 @@ import (
 )
 
 func skipIfNotMainBranch(t *testing.T) {
-	if utils.GetKcpRelease() != "main" {
+	if utils.GetKcpRelease().LessThan(semver.MustParse("0.31")) {
 		t.Skip("This test requires kcp >= 0.31.")
 	}
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -29,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/kcp-dev/logicalcluster/v3"
 	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	kcptenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
@@ -356,6 +356,16 @@ func changeClusterInURL(u string, newCluster logicalcluster.Path) string {
 	return strings.Replace(u, matches[0], newPath, 1)
 }
 
-func GetKcpRelease() string {
-	return os.Getenv("KCP_RELEASE")
+func GetKcpRelease() *semver.Version {
+	tag := getKcpTag()
+	if tag == "" {
+		tag = resources.ImageTag
+	}
+
+	parsed, err := semver.NewVersion(tag)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to determine effective kcp version, provider KCP_TAG is not a valid semver: %v", err))
+	}
+
+	return parsed
 }


### PR DESCRIPTION
## Summary
These got lost in #188 and I see no reason why we should already stop testing against 0.28, a supported kcp release. With the current config, we effectively tested against kcp 0.30.1 **and** release-0.30.

The main difference is that kcp 0.28 doesn't have a release with support for authentication on the cache server, so the e2e tests fail. We already have some logic to kind of sort of detect the kcp release and skip certain tests, but the logic could not catch this particular case.

To make this more palatable, I reworked the concept a bit: The setup scripts for the e2e tests will now not just resolve the branch name (`release-0.30` => `387ad6e`), but also *pull and re-tag* the image, so `387ad6e` becomes `0.30.999`. The re-tagged image is then preloaded into kind. The old `KCP_RELEASE` hack was re-used to supply a suitable release for `KCP_TAG=main`, but is otherwise not used in the tests anymore.

To actually handle the version differences, I added parsing logic to the image tag in the operator. If the tag fails to parse, no worries, we'll just use it but assume you have the latest and greatest kcp. If you need to opt-in to a specific release's treatment by the operator, tag your custom images with a semver.

## What Type of PR Is This?
/kind cleanup

## Release Notes
```release-note
NONE
```
