### PR TITLE
split AGENTS.md, have a dedicated README for the sdk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,14 +5,12 @@
 * Use `make imports` before committing any change to Go code.
 * Use `make modules` after any change to a `go.mod`.
 * Run `make lint-fix` before submitting a pull request.
+* When changing any file in `sdk/apis/`, run `make codegen`.
 * Run the e2e tests before submitting a pull request.
-* When possible, try to keep pull requests small and self-contained to make reviews easier.
-
-## SDK
-
-* Do not update dependencies in `sdk/go.mod` unless necessary to keep the kcp-operator compiling.
-* Specifically do not attempt to manually bump the Go version in any `go.mod` file in this project,
-  instead let `go mod tidy` take care of that.
+* When possible, try to keep pull requests small and self-contained to make reviews easier. Follow
+  the repository's `.github/pull_request_template.md` and make sure to focus more on the reasons,
+  background and encountered problems that motivated the change and less on reiterating code
+  changes.
 
 ## Documentation
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,48 @@
+# kcp Operator SDK
+
+This directory contains the kcp operator's SDK: re-usable Go API types and generated functions for
+integrating the kcp operator into 3rd-party applications.
+
+## Usage
+
+To install the SDK, simply `go get` it:
+
+```bash
+go get github.com/kcp-dev/kcp-operator/sdk@latest
+```
+
+and then in your code import the desired types:
+
+```go
+package main
+
+import operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+
+func createRootShard() *operatorv1alpha1.RootShard {
+   rs := &operatorv1alpha1.RootShard{}
+   rs.Name = "my-r00t"
+   rs.Namespace = "default"
+
+   return rs
+}
+```
+
+## SDK Design
+
+The SDK comes as a standalone Go module: `github.com/kcp-dev/kcp-operator/sdk`
+
+The module reduces the transitive dependencies that consumers have to worry about when they want to
+integrate the kcp operator. To that end, the SDK is meant to provide the broadest possible
+compatibility: dependencies are on the *lowest* version that is usable by the kcp operator. This
+drift between the operator's dependencies and those of the SDK is an intended feature of the SDK.
+
+The actual dependency versions used in the kcp operator binaries are controlled exclusively via the
+root directory's `go.mod`. Specifically, the SDK is not meant to propagate security fixes to
+consumers and force them to upgrade when it might be inconvenient to them.
+
+## Development Guidelines
+
+* Do not update the `go` constraint in the `go.mod` file manually, let `go mod tidy` update it only
+  when necessary. The `go` constraint has no influence on what Go version the operator is actually
+  built with. It can, however, cause serious annoyances for downstream consumers.
+* Likewise, only bump dependencies to keep the SDK compatible with the main module.


### PR DESCRIPTION
## Summary
I want to make sure folks do not blindly let AI agents update SDK dependencies, thinking they are doing the project a favor, when instead they often would just introduce a hassle for downstream consumers.

From what I understand, having a dedicated AGENTS.md in the sdk/ directory should accomplish that. However what I initially wrote as an AGENTS.md was, according to Claude, more of a README, which Claude also assured me would totally be respected by AI agents, too. :crossed_fingers: So I pivoted to having a nice README instead to make our human friends happy.

## What Type of PR Is This?
/kind documentation

## Release Notes
```release-note
NONE
```
