### PR TITLE
respect external port when constructing front-proxy Service/URLs

### DIFF
--- a/internal/resources/frontproxy/service.go
+++ b/internal/resources/frontproxy/service.go
@@ -36,14 +36,29 @@ func (r *reconciler) serviceName() string {
 	}
 }
 
+func (r *reconciler) getExternalPort() int {
+	// We're reconciling a regular FrontProxy.
+	if r.frontProxy != nil {
+		return utils.GetFrontProxyExternalPort(r.frontProxy, r.rootShard)
+	}
+
+	// We're reconciling the rootshard's internal proxy.
+	// This proxy is not meant to be exposed, but only used internally by
+	// the kcp-operator, so we never allow to customize its port.
+	return 6443
+}
+
 func (r *reconciler) serviceReconciler() reconciling.NamedServiceReconcilerFactory {
 	var tpl *operatorv1alpha1.ServiceTemplate
+
 	switch {
 	case r.frontProxy != nil:
 		tpl = r.frontProxy.Spec.ServiceTemplate
 	case r.rootShard.Spec.Proxy != nil:
 		tpl = r.rootShard.Spec.Proxy.ServiceTemplate
 	}
+
+	portNumber := r.getExternalPort()
 
 	return func() (string, reconciling.ServiceReconciler) {
 		return r.serviceName(), func(svc *corev1.Service) (*corev1.Service, error) {
@@ -57,7 +72,7 @@ func (r *reconciler) serviceReconciler() reconciling.NamedServiceReconcilerFacto
 
 			port.Name = "https"
 			port.Protocol = corev1.ProtocolTCP
-			port.Port = 6443
+			port.Port = int32(portNumber)
 			port.TargetPort = intstr.FromInt32(6443)
 			port.AppProtocol = ptr.To("https")
 

--- a/internal/resources/frontproxy/service_test.go
+++ b/internal/resources/frontproxy/service_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frontproxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+func TestGetExternalPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		frontProxy   *operatorv1alpha1.FrontProxy
+		rootShard    *operatorv1alpha1.RootShard
+		expectedPort int
+	}{
+		{
+			name: "FrontProxy with explicit External.Port",
+			frontProxy: &operatorv1alpha1.FrontProxy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-front-proxy"},
+				Spec: operatorv1alpha1.FrontProxySpec{
+					RootShard: operatorv1alpha1.RootShardConfig{
+						Reference: &corev1.LocalObjectReference{Name: "test-root-shard"},
+					},
+					External: operatorv1alpha1.ExternalConfig{
+						Port: 8443,
+					},
+				},
+			},
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-root-shard"},
+				Spec: operatorv1alpha1.RootShardSpec{
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "kcp.example.com",
+						Port:     6443,
+					},
+				},
+			},
+			expectedPort: 8443,
+		},
+		{
+			name: "FrontProxy with deprecated ExternalHostname including port",
+			frontProxy: &operatorv1alpha1.FrontProxy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-front-proxy"},
+				Spec: operatorv1alpha1.FrontProxySpec{
+					RootShard: operatorv1alpha1.RootShardConfig{
+						Reference: &corev1.LocalObjectReference{Name: "test-root-shard"},
+					},
+					ExternalHostname: "kcp.example.com:9443",
+				},
+			},
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-root-shard"},
+				Spec: operatorv1alpha1.RootShardSpec{
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "kcp.example.com",
+						Port:     6443,
+					},
+				},
+			},
+			expectedPort: 9443,
+		},
+		{
+			name: "FrontProxy External.Port takes precedence over deprecated ExternalHostname",
+			frontProxy: &operatorv1alpha1.FrontProxy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-front-proxy"},
+				Spec: operatorv1alpha1.FrontProxySpec{
+					RootShard: operatorv1alpha1.RootShardConfig{
+						Reference: &corev1.LocalObjectReference{Name: "test-root-shard"},
+					},
+					External: operatorv1alpha1.ExternalConfig{
+						Port: 8443,
+					},
+					ExternalHostname: "kcp.example.com:9443",
+				},
+			},
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-root-shard"},
+				Spec: operatorv1alpha1.RootShardSpec{
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "kcp.example.com",
+						Port:     6443,
+					},
+				},
+			},
+			expectedPort: 8443,
+		},
+		{
+			name: "FrontProxy falls back to RootShard External.Port",
+			frontProxy: &operatorv1alpha1.FrontProxy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-front-proxy"},
+				Spec: operatorv1alpha1.FrontProxySpec{
+					RootShard: operatorv1alpha1.RootShardConfig{
+						Reference: &corev1.LocalObjectReference{Name: "test-root-shard"},
+					},
+				},
+			},
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-root-shard"},
+				Spec: operatorv1alpha1.RootShardSpec{
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "kcp.example.com",
+						Port:     7443,
+					},
+				},
+			},
+			expectedPort: 7443,
+		},
+		{
+			name: "FrontProxy with ExternalHostname without a port defaults to 6443",
+			frontProxy: &operatorv1alpha1.FrontProxy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-front-proxy"},
+				Spec: operatorv1alpha1.FrontProxySpec{
+					RootShard: operatorv1alpha1.RootShardConfig{
+						Reference: &corev1.LocalObjectReference{Name: "test-root-shard"},
+					},
+					ExternalHostname: "kcp.example.com",
+				},
+			},
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-root-shard"},
+				Spec: operatorv1alpha1.RootShardSpec{
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "kcp.example.com",
+						Port:     7443,
+					},
+				},
+			},
+			expectedPort: 6443,
+		},
+		{
+			name: "FrontProxy with non-numeric port in ExternalHostname defaults to 6443",
+			frontProxy: &operatorv1alpha1.FrontProxy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-front-proxy"},
+				Spec: operatorv1alpha1.FrontProxySpec{
+					RootShard: operatorv1alpha1.RootShardConfig{
+						Reference: &corev1.LocalObjectReference{Name: "test-root-shard"},
+					},
+					ExternalHostname: "kcp.example.com:invalid",
+				},
+			},
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-root-shard"},
+				Spec: operatorv1alpha1.RootShardSpec{
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "kcp.example.com",
+						Port:     7443,
+					},
+				},
+			},
+			expectedPort: 6443,
+		},
+		{
+			name: "FrontProxy with no port configuration uses default 6443",
+			frontProxy: &operatorv1alpha1.FrontProxy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-front-proxy"},
+				Spec: operatorv1alpha1.FrontProxySpec{
+					RootShard: operatorv1alpha1.RootShardConfig{
+						Reference: &corev1.LocalObjectReference{Name: "test-root-shard"},
+					},
+				},
+			},
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-root-shard"},
+				Spec: operatorv1alpha1.RootShardSpec{
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "kcp.example.com",
+						Port:     0,
+					},
+				},
+			},
+			expectedPort: 6443,
+		},
+		{
+			name:       "RootShard internal proxy always uses default 6443",
+			frontProxy: nil,
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-root-shard"},
+				Spec: operatorv1alpha1.RootShardSpec{
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "kcp.example.com",
+						Port:     8443,
+					},
+				},
+			},
+			expectedPort: 6443,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rec *reconciler
+			if tt.frontProxy != nil {
+				rec = NewFrontProxy(tt.frontProxy, tt.rootShard)
+			} else {
+				rec = NewRootShardProxy(tt.rootShard)
+			}
+
+			actualPort := rec.getExternalPort()
+			require.Equal(t, tt.expectedPort, actualPort)
+		})
+	}
+}

--- a/internal/resources/kubeconfig/secret.go
+++ b/internal/resources/kubeconfig/secret.go
@@ -18,6 +18,7 @@ package kubeconfig
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 
 	"k8c.io/reconciler/pkg/reconciling"
@@ -122,11 +123,17 @@ func KubeconfigSecretReconciler(
 		}
 
 		var serverURL string
-		// New flow:
-		if frontProxy.Spec.External.Hostname != "" {
+		switch {
+		case frontProxy.Spec.External.Hostname != "":
 			serverURL = fmt.Sprintf("https://%s:%d", frontProxy.Spec.External.Hostname, frontProxy.Spec.External.Port)
-		} else {
-			// Old flow:
+		case frontProxy.Spec.ExternalHostname != "":
+			_, _, err := net.SplitHostPort(frontProxy.Spec.ExternalHostname)
+			if err == nil {
+				serverURL = fmt.Sprintf("https://%s", frontProxy.Spec.ExternalHostname)
+			} else {
+				serverURL = fmt.Sprintf("https://%s:6443", frontProxy.Spec.ExternalHostname)
+			}
+		default:
 			serverURL = fmt.Sprintf("https://%s:%d", rootShard.Spec.External.Hostname, rootShard.Spec.External.Port)
 		}
 

--- a/internal/resources/rootshard/service.go
+++ b/internal/resources/rootshard/service.go
@@ -31,25 +31,28 @@ import (
 func ServiceReconciler(rootShard *operatorv1alpha1.RootShard) reconciling.NamedServiceReconcilerFactory {
 	return func() (string, reconciling.ServiceReconciler) {
 		return resources.GetRootShardServiceName(rootShard), func(svc *corev1.Service) (*corev1.Service, error) {
-			labels := resources.GetRootShardResourceLabels(rootShard)
-			svc.SetLabels(labels)
-			svc.Spec.Type = corev1.ServiceTypeClusterIP
-			svc.Spec.Ports = []corev1.ServicePort{
-				{
-					Name:        "https",
-					Protocol:    corev1.ProtocolTCP,
-					Port:        6443,
-					TargetPort:  intstr.FromInt32(6443),
-					AppProtocol: ptr.To("https"),
-				},
-				{
+			ports := []corev1.ServicePort{{
+				Name:        "https",
+				Protocol:    corev1.ProtocolTCP,
+				Port:        6443,
+				TargetPort:  intstr.FromInt32(6443),
+				AppProtocol: ptr.To("https"),
+			}}
+
+			if rootShard.Spec.KCPVirtualWorkspace == nil {
+				ports = append(ports, corev1.ServicePort{
 					Name:        "https-virtual-workspaces",
 					Protocol:    corev1.ProtocolTCP,
 					Port:        6444,
 					TargetPort:  intstr.FromInt32(6444),
 					AppProtocol: ptr.To("https"),
-				},
+				})
 			}
+
+			labels := resources.GetRootShardResourceLabels(rootShard)
+			svc.SetLabels(labels)
+			svc.Spec.Type = corev1.ServiceTypeClusterIP
+			svc.Spec.Ports = ports
 			svc.Spec.Selector = labels
 
 			return utils.ApplyServiceTemplate(svc, rootShard.Spec.ServiceTemplate), nil

--- a/internal/resources/shard/service.go
+++ b/internal/resources/shard/service.go
@@ -31,25 +31,28 @@ import (
 func ServiceReconciler(shard *operatorv1alpha1.Shard) reconciling.NamedServiceReconcilerFactory {
 	return func() (string, reconciling.ServiceReconciler) {
 		return resources.GetShardServiceName(shard), func(svc *corev1.Service) (*corev1.Service, error) {
-			labels := resources.GetShardResourceLabels(shard)
-			svc.SetLabels(labels)
-			svc.Spec.Type = corev1.ServiceTypeClusterIP
-			svc.Spec.Ports = []corev1.ServicePort{
-				{
-					Name:        "https",
-					Protocol:    corev1.ProtocolTCP,
-					Port:        6443,
-					TargetPort:  intstr.FromInt32(6443),
-					AppProtocol: ptr.To("https"),
-				},
-				{
+			ports := []corev1.ServicePort{{
+				Name:        "https",
+				Protocol:    corev1.ProtocolTCP,
+				Port:        6443,
+				TargetPort:  intstr.FromInt32(6443),
+				AppProtocol: ptr.To("https"),
+			}}
+
+			if shard.Spec.KCPVirtualWorkspace == nil {
+				ports = append(ports, corev1.ServicePort{
 					Name:        "https-virtual-workspaces",
 					Protocol:    corev1.ProtocolTCP,
 					Port:        6444,
 					TargetPort:  intstr.FromInt32(6444),
 					AppProtocol: ptr.To("https"),
-				},
+				})
 			}
+
+			labels := resources.GetShardResourceLabels(shard)
+			svc.SetLabels(labels)
+			svc.Spec.Type = corev1.ServiceTypeClusterIP
+			svc.Spec.Ports = ports
 			svc.Spec.Selector = labels
 
 			return utils.ApplyServiceTemplate(svc, shard.Spec.ServiceTemplate), nil

--- a/internal/resources/utils/frontproxy.go
+++ b/internal/resources/utils/frontproxy.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"net"
+	"strconv"
+
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+func GetFrontProxyExternalPort(fp *operatorv1alpha1.FrontProxy, r *operatorv1alpha1.RootShard) int {
+	// easy, the user explicitly configured an external port on the FrontProxy itself
+	if port := fp.Spec.External.Port; port > 0 {
+		return int(port)
+	}
+
+	// fallback to deprecated ExternalHostname
+	if extName := fp.Spec.ExternalHostname; extName != "" {
+		_, port, err := net.SplitHostPort(extName)
+		if err == nil {
+			parsed, err := strconv.Atoi(port)
+			if err == nil {
+				return parsed
+			}
+		}
+
+		// no port was given in the URL; assume the default
+		return 6443
+	}
+
+	// if nothing valid is configured on the FrontProxy, check the RootShard
+	if r != nil {
+		if port := r.Spec.External.Port; port > 0 {
+			return int(port)
+		}
+	}
+
+	// last resort, fallback to the default kcp port
+	return 6443
+}


### PR DESCRIPTION
## Summary
The kcp-oeprator did not respect an explicit external port when constructing Services and Kubeconfigs for the front-proxy. This PR fixes that. It also makes the port for the virtual workspace dependent on whether or not the integrated VWs are even enabled.

## What Type of PR Is This?
/kind bug

## Related Issue(s)
Fixes #211

## Release Notes
```release-note
Fix external port not being used in front-proxy Service and kubeconfigs.
```
