### PR TITLE
Add --requestheader-allowed-names where necessary

### DIFF
--- a/internal/resources/frontproxy/certificates.go
+++ b/internal/resources/frontproxy/certificates.go
@@ -50,9 +50,9 @@ func (r *reconciler) certName(certKind operatorv1alpha1.Certificate) string {
 
 func (r *reconciler) certCommonName() string {
 	if r.frontProxy != nil {
-		return "kcp-front-proxy"
+		return resources.FrontProxyCommonName
 	} else {
-		return "kcp-root-shard-proxy"
+		return resources.RootShardProxyCommonName
 	}
 }
 

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -27,6 +27,12 @@ import (
 )
 
 const (
+	// FrontProxyCommonName is the CommonName used in the requestheader client certificate for a FrontProxy.
+	FrontProxyCommonName = "kcp-front-proxy"
+
+	// RootShardProxyCommonName is the CommonName used in the requestheader client certificate for a RootShard's built-in proxy.
+	RootShardProxyCommonName = "kcp-root-shard-proxy"
+
 	ImageRepository = "ghcr.io/kcp-dev/kcp"
 
 	// ImageTag is the default tag to be used for any kcp component.

--- a/internal/resources/rootshard/deployment.go
+++ b/internal/resources/rootshard/deployment.go
@@ -218,6 +218,7 @@ func getArgs(rootShard *operatorv1alpha1.RootShard, kcpVW *operatorv1alpha1.Virt
 
 		// Requestheader configuration.
 		fmt.Sprintf("--requestheader-client-ca-file=%s/tls.crt", getCAMountPath(operatorv1alpha1.RequestHeaderClientCA)),
+		fmt.Sprintf("--requestheader-allowed-names=%s,%s", resources.FrontProxyCommonName, resources.RootShardProxyCommonName),
 		"--requestheader-username-headers=X-Remote-User",
 		"--requestheader-group-headers=X-Remote-Group",
 		"--requestheader-extra-headers-prefix=X-Remote-Extra-",

--- a/internal/resources/shard/deployment.go
+++ b/internal/resources/shard/deployment.go
@@ -238,6 +238,7 @@ func getArgs(shard *operatorv1alpha1.Shard, rootShard *operatorv1alpha1.RootShar
 
 		// Requestheader configuration.
 		fmt.Sprintf("--requestheader-client-ca-file=%s/tls.crt", getCAMountPath(operatorv1alpha1.RequestHeaderClientCA)),
+		fmt.Sprintf("--requestheader-allowed-names=%s,%s", resources.FrontProxyCommonName, resources.RootShardProxyCommonName),
 		"--requestheader-username-headers=X-Remote-User",
 		"--requestheader-group-headers=X-Remote-Group",
 		"--requestheader-extra-headers-prefix=X-Remote-Extra-",

--- a/internal/resources/virtualworkspace/deployment.go
+++ b/internal/resources/virtualworkspace/deployment.go
@@ -248,6 +248,7 @@ func getArgs(vw *operatorv1alpha1.VirtualWorkspace, rootShard *operatorv1alpha1.
 
 		// requestheader CA
 		fmt.Sprintf("--requestheader-client-ca-file=%s/tls.crt", getCAMountPath(operatorv1alpha1.RequestHeaderClientCA)),
+		fmt.Sprintf("--requestheader-allowed-names=%s,%s", resources.FrontProxyCommonName, resources.RootShardProxyCommonName),
 		"--requestheader-username-headers=X-Remote-User",
 		"--requestheader-group-headers=X-Remote-Group",
 		"--requestheader-extra-headers-prefix=X-Remote-Extra-",


### PR DESCRIPTION
## Summary
<!--
Please provide a description that explains *why* your PR is changing something
in the codebase, and focus less on what *what* you're changing. The following are
good questions to ask yourself when writing the PR summary:

* What are the problems you are trying to solve?
* What assumptions did you make when implementing your changes?
* Which workflows will be affected/improved by your change?
-->

Adds --requestheader-allowed-names to RootShard, Shard and VirtualWorkspace deployments.

k/k 1.35 requires --requestheader-allowed-names to be passed if --requestheader-client-ca-file and --client-ca-file point to the same cert, otherwise the apiserver exits with non-zero return code immediately.

## What Type of PR Is This?
<!--
Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

## Related Issue(s)
Fixes https://github.com/kcp-dev/kcp/issues/4032

## Release Notes
<!--
Please add a release note in the block below.
Leave NONE only if no user-facing changes are in this PR.
-->
```release-note
Adds --requestheader-allowed-names to RootShard, Shard and VirtualWorkspace deployments
```
