### PR TITLE
Add shardBaseURL hostname to certificate DNS SANs

### DIFF
--- a/internal/resources/rootshard/certificates.go
+++ b/internal/resources/rootshard/certificates.go
@@ -20,6 +20,8 @@ import (
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
 	"github.com/kcp-dev/kcp-operator/internal/resources"
 	"github.com/kcp-dev/kcp-operator/internal/resources/utils"
@@ -56,10 +58,7 @@ func ServerCertificateReconciler(rootShard *operatorv1alpha1.RootShard) reconcil
 					certmanagerv1.UsageDigitalSignature,
 				},
 
-				DNSNames: []string{
-					resources.GetRootShardBaseHost(rootShard),
-					rootShard.Spec.External.Hostname,
-				},
+				DNSNames: buildRootShardDNSNames(rootShard),
 
 				IssuerRef: certmanagermetav1.ObjectReference{
 					Name:  resources.GetRootShardCAName(rootShard, operatorv1alpha1.ServerCA),
@@ -344,4 +343,23 @@ func ClientCertificateReconciler(rootShard *operatorv1alpha1.RootShard) reconcil
 			return utils.ApplyCertificateTemplate(cert, &template), nil
 		}
 	}
+}
+
+// buildRootShardDNSNames builds the list of DNS names for the root shard server certificate.
+// It includes the internal Kubernetes service host, the external hostname, and if shardBaseURL
+// is set, it also extracts and includes the hostname from that URL.
+func buildRootShardDNSNames(rootShard *operatorv1alpha1.RootShard) []string {
+	dnsNames := sets.New(
+		resources.GetRootShardBaseHost(rootShard),
+		rootShard.Spec.External.Hostname,
+	)
+
+	// If shardBaseURL is set, extract and add its hostname
+	if rootShard.Spec.ShardBaseURL != "" {
+		if hostname := utils.ExtractHostnameFromURL(rootShard.Spec.ShardBaseURL); hostname != "" {
+			dnsNames.Insert(hostname)
+		}
+	}
+
+	return sets.List(dnsNames)
 }

--- a/internal/resources/rootshard/certificates_test.go
+++ b/internal/resources/rootshard/certificates_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rootshard
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+func TestBuildRootShardDNSNames(t *testing.T) {
+	tests := []struct {
+		name      string
+		rootShard *operatorv1alpha1.RootShard
+		expected  []string
+	}{
+		{
+			name: "without shardBaseURL",
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-shard",
+					Namespace: "kcp",
+				},
+				Spec: operatorv1alpha1.RootShardSpec{
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						ClusterDomain: "cluster.local",
+					},
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "api.example.com",
+					},
+				},
+			},
+			expected: []string{
+				"test-shard-kcp.kcp.svc.cluster.local",
+				"api.example.com",
+			},
+		},
+		{
+			name: "with shardBaseURL matching external hostname",
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-shard",
+					Namespace: "kcp",
+				},
+				Spec: operatorv1alpha1.RootShardSpec{
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						ClusterDomain: "cluster.local",
+						ShardBaseURL:  "https://api.example.com:6443",
+					},
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "api.example.com",
+					},
+				},
+			},
+			expected: []string{
+				"test-shard-kcp.kcp.svc.cluster.local",
+				"api.example.com",
+			},
+		},
+		{
+			name: "with shardBaseURL different from external hostname",
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "root",
+					Namespace: "kcp",
+				},
+				Spec: operatorv1alpha1.RootShardSpec{
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						ClusterDomain: "cluster.local",
+						ShardBaseURL:  "https://root.shard.kcp.example.com:6443",
+					},
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "api.kcp.example.com",
+					},
+				},
+			},
+			expected: []string{
+				"root-kcp.kcp.svc.cluster.local",
+				"api.kcp.example.com",
+				"root.shard.kcp.example.com",
+			},
+		},
+		{
+			name: "with invalid shardBaseURL",
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-shard",
+					Namespace: "kcp",
+				},
+				Spec: operatorv1alpha1.RootShardSpec{
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						ClusterDomain: "cluster.local",
+						ShardBaseURL:  "not-a-valid-url",
+					},
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "api.example.com",
+					},
+				},
+			},
+			expected: []string{
+				"test-shard-kcp.kcp.svc.cluster.local",
+				"api.example.com",
+			},
+		},
+		{
+			name: "with shardBaseURL containing subdomain",
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prod",
+					Namespace: "kcp-system",
+				},
+				Spec: operatorv1alpha1.RootShardSpec{
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						ShardBaseURL: "https://prod.shard.kcp.devsecops.dev.codefabric.cloud:6443",
+					},
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "api.kcp.devsecops.dev.codefabric.cloud",
+					},
+				},
+			},
+			expected: []string{
+				"prod-kcp.kcp-system.svc.cluster.local",
+				"api.kcp.devsecops.dev.codefabric.cloud",
+				"prod.shard.kcp.devsecops.dev.codefabric.cloud",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildRootShardDNSNames(tt.rootShard)
+			assert.ElementsMatch(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/resources/shard/certificates.go
+++ b/internal/resources/shard/certificates.go
@@ -22,6 +22,8 @@ import (
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
 	"github.com/kcp-dev/kcp-operator/internal/resources"
 	"github.com/kcp-dev/kcp-operator/internal/resources/utils"
@@ -60,10 +62,7 @@ func ServerCertificateReconciler(shard *operatorv1alpha1.Shard, rootShard *opera
 					certmanagerv1.UsageDigitalSignature,
 				},
 
-				DNSNames: []string{
-					"localhost",
-					resources.GetShardBaseHost(shard),
-				},
+				DNSNames: buildShardDNSNames(shard),
 
 				IssuerRef: certmanagermetav1.ObjectReference{
 					Name:  resources.GetRootShardCAName(rootShard, operatorv1alpha1.ServerCA),
@@ -306,4 +305,23 @@ func ExternalLogicalClusterAdminCertificateReconciler(shard *operatorv1alpha1.Sh
 			return utils.ApplyCertificateTemplate(cert, &template), nil
 		}
 	}
+}
+
+// buildShardDNSNames builds the list of DNS names for the shard server certificate.
+// It includes localhost, the internal Kubernetes service host, and if shardBaseURL
+// is set, it also extracts and includes the hostname from that URL.
+func buildShardDNSNames(shard *operatorv1alpha1.Shard) []string {
+	dnsNames := sets.New(
+		"localhost",
+		resources.GetShardBaseHost(shard),
+	)
+
+	// If shardBaseURL is set, extract and add its hostname
+	if shard.Spec.ShardBaseURL != "" {
+		if hostname := utils.ExtractHostnameFromURL(shard.Spec.ShardBaseURL); hostname != "" {
+			dnsNames.Insert(hostname)
+		}
+	}
+
+	return sets.List(dnsNames)
 }

--- a/internal/resources/shard/certificates_test.go
+++ b/internal/resources/shard/certificates_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shard
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+func TestBuildShardDNSNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		shard    *operatorv1alpha1.Shard
+		expected []string
+	}{
+		{
+			name: "without shardBaseURL",
+			shard: &operatorv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-shard",
+					Namespace: "kcp",
+				},
+				Spec: operatorv1alpha1.ShardSpec{
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						ClusterDomain: "cluster.local",
+					},
+				},
+			},
+			expected: []string{
+				"localhost",
+				"test-shard-shard-kcp.kcp.svc.cluster.local",
+			},
+		},
+		{
+			name: "with shardBaseURL",
+			shard: &operatorv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "worker-1",
+					Namespace: "kcp",
+				},
+				Spec: operatorv1alpha1.ShardSpec{
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						ClusterDomain: "cluster.local",
+						ShardBaseURL:  "https://worker-1.shard.kcp.example.com:6443",
+					},
+				},
+			},
+			expected: []string{
+				"localhost",
+				"worker-1-shard-kcp.kcp.svc.cluster.local",
+				"worker-1.shard.kcp.example.com",
+			},
+		},
+		{
+			name: "with shardBaseURL matching localhost",
+			shard: &operatorv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "local-shard",
+					Namespace: "kcp",
+				},
+				Spec: operatorv1alpha1.ShardSpec{
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						ShardBaseURL: "https://localhost:6443",
+					},
+				},
+			},
+			expected: []string{
+				"localhost",
+				"local-shard-shard-kcp.kcp.svc.cluster.local",
+			},
+		},
+		{
+			name: "with invalid shardBaseURL",
+			shard: &operatorv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-shard",
+					Namespace: "kcp",
+				},
+				Spec: operatorv1alpha1.ShardSpec{
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						ShardBaseURL: "not-a-valid-url",
+					},
+				},
+			},
+			expected: []string{
+				"localhost",
+				"test-shard-shard-kcp.kcp.svc.cluster.local",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildShardDNSNames(tt.shard)
+			assert.ElementsMatch(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/resources/utils/certificates.go
+++ b/internal/resources/utils/certificates.go
@@ -21,6 +21,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"maps"
+	"net/url"
 	"os"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -243,4 +244,19 @@ func MergeCABundlesFiles(caFile1, caFile2 string) ([]byte, error) {
 	merged = append(merged, caFile2Content...)
 
 	return merged, nil
+}
+
+// ExtractHostnameFromURL extracts the hostname from a URL string.
+// Returns empty string if the URL is invalid or empty.
+func ExtractHostnameFromURL(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+
+	return parsed.Hostname()
 }

--- a/internal/resources/utils/certificates_test.go
+++ b/internal/resources/utils/certificates_test.go
@@ -122,3 +122,64 @@ YWJjZGVmZ2hpams=
 		})
 	}
 }
+
+func TestExtractHostnameFromURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "empty URL",
+			url:      "",
+			expected: "",
+		},
+		{
+			name:     "valid URL with https",
+			url:      "https://api.example.com",
+			expected: "api.example.com",
+		},
+		{
+			name:     "valid URL with port",
+			url:      "https://api.example.com:6443",
+			expected: "api.example.com",
+		},
+		{
+			name:     "valid URL with http",
+			url:      "http://localhost:8080",
+			expected: "localhost",
+		},
+		{
+			name:     "URL with path",
+			url:      "https://api.example.com:6443/path/to/resource",
+			expected: "api.example.com",
+		},
+		{
+			name:     "subdomain URL",
+			url:      "https://root.shard.kcp.example.com:6443",
+			expected: "root.shard.kcp.example.com",
+		},
+		{
+			name:     "invalid URL",
+			url:      "not-a-valid-url",
+			expected: "",
+		},
+		{
+			name:     "URL with IPv4 address",
+			url:      "https://192.168.1.1:6443",
+			expected: "192.168.1.1",
+		},
+		{
+			name:     "URL with IPv6 address",
+			url:      "https://[2001:db8::1]:6443",
+			expected: "2001:db8::1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractHostnameFromURL(tt.url)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #213

When spec.shardBaseURL is set to a value different from spec.external.hostname, the shardBaseURL hostname is now extracted and included in the server certificate's DNS Subject Alternative Names.

This prevents TLS certificate validation errors when clients connect using the shardBaseURL instead of the external hostname.

Changes:
- Add ExtractHostnameFromURL utility function to parse hostnames from URLs
- Update RootShard server certificates to include shardBaseURL hostname
- Update Shard server certificates to include shardBaseURL hostname
- Add comprehensive tests for URL hostname extraction
- Add tests for DNS name building in both RootShard and Shard certificates

## What Type of PR Is This?
/kind bug

## Related Issue(s)
Fixes #213

## Release Notes
```release-note
Fix: RootShard shardBaseURL not added to certificate dns names 
```
