### PR TITLE
deprecate ClientSecret in the OIDC Configuration

### DIFF
--- a/config/crd/bases/operator.kcp.io_frontproxies.yaml
+++ b/config/crd/bases/operator.kcp.io_frontproxies.yaml
@@ -112,8 +112,10 @@ spec:
                         type: string
                       clientSecret:
                         description: |-
-                          Optionally provide the client secret for the OIDC client. This is not used by kcp itself, but is used to generate
-                          a OIDC kubeconfig that can be shared with users to log in via the OIDC provider.
+                          ClientSecret is the OIDC client secret configured on the issuer side for this kcp instance.
+                          This is not used by kcp itself, but is used to generate a OIDC kubeconfig that can be
+                          shared with users to log in via the OIDC provider.
+                          Deprecated: kube OIDC is secretless.
                         type: string
                       groupsClaim:
                         description: 'Experimental: Optionally provides a custom claim

--- a/config/crd/bases/operator.kcp.io_rootshards.yaml
+++ b/config/crd/bases/operator.kcp.io_rootshards.yaml
@@ -174,8 +174,10 @@ spec:
                         type: string
                       clientSecret:
                         description: |-
-                          Optionally provide the client secret for the OIDC client. This is not used by kcp itself, but is used to generate
-                          a OIDC kubeconfig that can be shared with users to log in via the OIDC provider.
+                          ClientSecret is the OIDC client secret configured on the issuer side for this kcp instance.
+                          This is not used by kcp itself, but is used to generate a OIDC kubeconfig that can be
+                          shared with users to log in via the OIDC provider.
+                          Deprecated: kube OIDC is secretless.
                         type: string
                       groupsClaim:
                         description: 'Experimental: Optionally provides a custom claim

--- a/config/crd/bases/operator.kcp.io_shards.yaml
+++ b/config/crd/bases/operator.kcp.io_shards.yaml
@@ -174,8 +174,10 @@ spec:
                         type: string
                       clientSecret:
                         description: |-
-                          Optionally provide the client secret for the OIDC client. This is not used by kcp itself, but is used to generate
-                          a OIDC kubeconfig that can be shared with users to log in via the OIDC provider.
+                          ClientSecret is the OIDC client secret configured on the issuer side for this kcp instance.
+                          This is not used by kcp itself, but is used to generate a OIDC kubeconfig that can be
+                          shared with users to log in via the OIDC provider.
+                          Deprecated: kube OIDC is secretless.
                         type: string
                       groupsClaim:
                         description: 'Experimental: Optionally provides a custom claim

--- a/sdk/apis/operator/v1alpha1/common.go
+++ b/sdk/apis/operator/v1alpha1/common.go
@@ -418,8 +418,11 @@ type OIDCConfiguration struct {
 	// ClientID is the OIDC client ID configured on the issuer side for this kcp instance.
 	ClientID string `json:"clientID"`
 
-	// Optionally provide the client secret for the OIDC client. This is not used by kcp itself, but is used to generate
-	// a OIDC kubeconfig that can be shared with users to log in via the OIDC provider.
+	// ClientSecret is the OIDC client secret configured on the issuer side for this kcp instance.
+	// This is not used by kcp itself, but is used to generate a OIDC kubeconfig that can be
+	// shared with users to log in via the OIDC provider.
+	// +optional
+	// Deprecated: kube OIDC is secretless.
 	ClientSecret string `json:"clientSecret,omitempty"`
 
 	// Experimental: Optionally provides a custom claim for fetching groups. The claim must be a string or an array of strings.


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.md.

-->

## Summary
```
change deprecates the ClientSecret field in the OIDC Configuration.
```
<!--
Please provide a description that explains *why* your PR is changing something
in the codebase, and focus less on what *what* you're changing. The following are
good questions to ask yourself when writing the PR summary:

* What are the problems you are trying to solve?
* What assumptions did you make when implementing your changes?
* Which workflows will be affected/improved by your change?
-->

## What Type of PR Is This?
/kind deprecation
<!--
Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

## Related Issue(s)
Fixes #

## Release Notes
<!--
Please add a release note in the block below.
Leave NONE only if no user-facing changes are in this PR.
-->
```release-note
Deprecated ClientSecret field
```
