### PR TITLE
Pass imagePullSecrets from ImageSpec to Deployments

### DIFF
--- a/internal/resources/cacheserver/deployment.go
+++ b/internal/resources/cacheserver/deployment.go
@@ -96,8 +96,8 @@ func DeploymentReconciler(server *operatorv1alpha1.CacheServer) reconciling.Name
 
 			dep.Spec.Template.SetLabels(labels)
 
-			// TODO: Why do we discard the imagePullSecrets?
-			image, _, version := resources.GetImageSettings(server.Spec.Image)
+			// Pass imagePullSecrets from the image spec to the pod spec.
+			image, imagePullSecrets, version := resources.GetImageSettings(server.Spec.Image)
 
 			volumes, volumeMounts := getVolumeMounts(server)
 
@@ -163,6 +163,7 @@ func DeploymentReconciler(server *operatorv1alpha1.CacheServer) reconciling.Name
 				},
 			}}
 			dep.Spec.Template.Spec.Volumes = volumes
+			dep.Spec.Template.Spec.ImagePullSecrets = imagePullSecrets
 
 			dep = utils.ApplyDeploymentTemplate(dep, server.Spec.DeploymentTemplate)
 

--- a/internal/resources/frontproxy/deployment.go
+++ b/internal/resources/frontproxy/deployment.go
@@ -69,7 +69,7 @@ func (r *reconciler) deploymentReconciler() reconciling.NamedDeploymentReconcile
 			}
 			dep.Spec.Template.SetLabels(r.resourceLabels)
 
-			image, _, _ := resources.GetImageSettings(imageSpec)
+			image, imagePullSecrets, _ := resources.GetImageSettings(imageSpec)
 			args := r.getArgs()
 
 			container := corev1.Container{
@@ -212,6 +212,8 @@ func (r *reconciler) deploymentReconciler() reconciling.NamedDeploymentReconcile
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				utils.ApplyResources(container, depResources),
 			}
+
+			dep.Spec.Template.Spec.ImagePullSecrets = imagePullSecrets
 
 			dep = utils.ApplyDeploymentTemplate(dep, template)
 

--- a/internal/resources/frontproxy/deployment_test.go
+++ b/internal/resources/frontproxy/deployment_test.go
@@ -491,6 +491,71 @@ func TestDeploymentReconciler(t *testing.T) {
 				}), "Webhook config volume mount not found")
 			},
 		},
+		{
+			name: "imagePullSecrets from image spec are passed to deployment",
+			frontProxy: &operatorv1alpha1.FrontProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-front-proxy",
+				},
+				Spec: operatorv1alpha1.FrontProxySpec{
+					RootShard: operatorv1alpha1.RootShardConfig{
+						Reference: &corev1.LocalObjectReference{
+							Name: "test-root-shard",
+						},
+					},
+					Image: &operatorv1alpha1.ImageSpec{
+						Repository: "private-registry.example.com/kcp",
+						Tag:        "v1.0.0",
+						ImagePullSecrets: []corev1.LocalObjectReference{
+							{Name: "registry-secret-1"},
+							{Name: "registry-secret-2"},
+						},
+					},
+				},
+			},
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-root-shard",
+				},
+			},
+			expectedName: resources.GetFrontProxyDeploymentName(&operatorv1alpha1.FrontProxy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-front-proxy"},
+			}),
+			validateDeploy: func(t *testing.T, dep *appsv1.Deployment) {
+				container := dep.Spec.Template.Spec.Containers[0]
+				assert.Equal(t, "private-registry.example.com/kcp:v1.0.0", container.Image)
+
+				require.Len(t, dep.Spec.Template.Spec.ImagePullSecrets, 2)
+				assert.Equal(t, "registry-secret-1", dep.Spec.Template.Spec.ImagePullSecrets[0].Name)
+				assert.Equal(t, "registry-secret-2", dep.Spec.Template.Spec.ImagePullSecrets[1].Name)
+			},
+		},
+		{
+			name: "no imagePullSecrets when image spec has none",
+			frontProxy: &operatorv1alpha1.FrontProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-front-proxy",
+				},
+				Spec: operatorv1alpha1.FrontProxySpec{
+					RootShard: operatorv1alpha1.RootShardConfig{
+						Reference: &corev1.LocalObjectReference{
+							Name: "test-root-shard",
+						},
+					},
+				},
+			},
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-root-shard",
+				},
+			},
+			expectedName: resources.GetFrontProxyDeploymentName(&operatorv1alpha1.FrontProxy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-front-proxy"},
+			}),
+			validateDeploy: func(t *testing.T, dep *appsv1.Deployment) {
+				assert.Empty(t, dep.Spec.Template.Spec.ImagePullSecrets)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/resources/utils/shard.go
+++ b/internal/resources/utils/shard.go
@@ -139,10 +139,10 @@ func ApplyCommonShardConfig(deployment *appsv1.Deployment, spec *operatorv1alpha
 		deployment.Spec.Replicas = ptr.To[int32](2)
 	}
 
-	// set container image
-	image, _, _ := resources.GetImageSettings(spec.Image)
+	// set container image and imagePullSecrets
+	image, imagePullSecrets, _ := resources.GetImageSettings(spec.Image)
 	container.Image = image
-
+	deployment.Spec.Template.Spec.ImagePullSecrets = imagePullSecrets
 	deployment.Spec.Template.Spec.Containers[0] = container
 
 	deployment = applyEtcdConfiguration(deployment, spec.Etcd)

--- a/internal/resources/virtualworkspace/deployment.go
+++ b/internal/resources/virtualworkspace/deployment.go
@@ -195,7 +195,7 @@ func DeploymentReconciler(vw *operatorv1alpha1.VirtualWorkspace, rootShard *oper
 				volumeMounts = append(volumeMounts, vm)
 			}
 
-			image, _, _ := resources.GetImageSettings(vw.Spec.Image)
+			image, imagePullSecrets, _ := resources.GetImageSettings(vw.Spec.Image)
 
 			container := corev1.Container{
 				Name:         ServerContainerName,
@@ -209,6 +209,7 @@ func DeploymentReconciler(vw *operatorv1alpha1.VirtualWorkspace, rootShard *oper
 
 			dep.Spec.Template.Spec.Containers = []corev1.Container{container}
 			dep.Spec.Template.Spec.Volumes = volumes
+			dep.Spec.Template.Spec.ImagePullSecrets = imagePullSecrets
 
 			if vw.Spec.Replicas != nil {
 				dep.Spec.Replicas = vw.Spec.Replicas


### PR DESCRIPTION
## Summary

Propagate imagePullSecrets from ImageSpec to generated Deployments across all four deployment generators (CacheServer, Shard/RootShard, FrontProxy, VirtualWorkspace).

Previously, `resources.GetImageSettings()` returned imagePullSecrets but all generators discarded them by assigning to `_`. This fix captures and sets them on the Deployment's PodSpec.

Fixes #181

```release-note
Propagate imagePullSecrets from component specs to generated Deployments
```

## Changes

- cacheserver/deployment.go: capture and set imagePullSecrets
- utils/shard.go: capture and set imagePullSecrets (covers RootShard and Shard)
- frontproxy/deployment.go: capture and set imagePullSecrets
- virtualworkspace/deployment.go: capture and set imagePullSecrets
- frontproxy/deployment_test.go: add test cases for imagePullSecrets propagation