### PR TITLE
bump to Go 1.26.3

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
           command:
             - make
             - verify
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
           command:
             - make
             - lint
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
           command:
             - make
             - test
@@ -86,7 +86,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -109,7 +109,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -132,7 +132,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -156,7 +156,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
           command:
             - hack/ci/run-e2e-tests.sh
           resources:
@@ -176,7 +176,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.26.2 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.26.3 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
Pure maintenance.

## What Type of PR Is This?
/kind chore

## Release Notes
```release-note
Update to Go 1.26.3
```
