### PR TITLE
bump to Go 1.26.4

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # tag=v6.1.0
         with:
-          go-version: v1.26.2
+          go-version: v1.26.4
           cache: true
 
       - name: Setup Python

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.4-1
           command:
             - make
             - verify
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.4-1
           command:
             - make
             - lint
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.4-1
           command:
             - make
             - test
@@ -86,7 +86,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.4-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -109,7 +109,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.4-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -132,7 +132,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.4-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -156,7 +156,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.4-1
           command:
             - hack/ci/run-e2e-tests.sh
           resources:
@@ -176,7 +176,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.3-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.4-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.26.3 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.26.4 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
That time of the month again.

## What Type of PR Is This?
/kind chore

## Release Notes
```release-note
Update to Go 1.26.4.
```
