### PR TITLE
Fix shard-direct virtual workspace access for embedded virtual workspaces

### DIFF
--- a/internal/resources/frontproxy/deployment.go
+++ b/internal/resources/frontproxy/deployment.go
@@ -218,7 +218,7 @@ func (r *reconciler) deploymentReconciler() reconciling.NamedDeploymentReconcile
 			dep = utils.ApplyDeploymentTemplate(dep, template)
 
 			if r.frontProxy != nil {
-				dep = utils.ApplyAuthConfigurationWithServiceAccount(dep, r.frontProxy.Spec.Auth, r.rootShard)
+				dep = utils.ApplyAuthConfiguration(dep, r.frontProxy.Spec.Auth, r.rootShard)
 
 				// If frontproxy has bundle annotation, store desired replicas in annotation then scale deployment to 0 locally
 				if r.frontProxy.Annotations != nil && r.frontProxy.Annotations[resources.BundleAnnotation] != "" {

--- a/internal/resources/frontproxy/deployment.go
+++ b/internal/resources/frontproxy/deployment.go
@@ -218,7 +218,7 @@ func (r *reconciler) deploymentReconciler() reconciling.NamedDeploymentReconcile
 			dep = utils.ApplyDeploymentTemplate(dep, template)
 
 			if r.frontProxy != nil {
-				dep = utils.ApplyFrontProxyAuthConfiguration(dep, r.frontProxy.Spec.Auth, r.rootShard)
+				dep = utils.ApplyAuthConfigurationWithServiceAccount(dep, r.frontProxy.Spec.Auth, r.rootShard)
 
 				// If frontproxy has bundle annotation, store desired replicas in annotation then scale deployment to 0 locally
 				if r.frontProxy.Annotations != nil && r.frontProxy.Annotations[resources.BundleAnnotation] != "" {

--- a/internal/resources/rootshard/deployment.go
+++ b/internal/resources/rootshard/deployment.go
@@ -209,7 +209,7 @@ func DeploymentReconciler(rootShard *operatorv1alpha1.RootShard, kcpVW *operator
 			// endpoints shard-direct via its VirtualWorkspaceURL, bypassing the
 			// front-proxy, so the shard itself must validate ServiceAccount
 			// tokens issued by any shard.
-			dep = utils.ApplyAuthConfigurationWithServiceAccount(dep, rootShard.Spec.Auth, rootShard)
+			dep = utils.ApplyAuthConfiguration(dep, rootShard.Spec.Auth, rootShard)
 
 			// If rootshard has bundle annotation, store desired replicas in annotation then scale deployment to 0 locally
 			if rootShard.Annotations != nil && rootShard.Annotations[resources.BundleAnnotation] != "" {

--- a/internal/resources/rootshard/deployment.go
+++ b/internal/resources/rootshard/deployment.go
@@ -204,7 +204,12 @@ func DeploymentReconciler(rootShard *operatorv1alpha1.RootShard, kcpVW *operator
 			dep = utils.ApplyCommonShardDeploymentProperties(dep)
 			dep = utils.ApplyCommonShardConfig(dep, &rootShard.Spec.CommonShardSpec)
 			dep = utils.ApplyDeploymentTemplate(dep, rootShard.Spec.DeploymentTemplate)
-			dep = utils.ApplyAuthConfiguration(dep, rootShard.Spec.Auth)
+			// Use the ServiceAccount-aware variant: external clients (e.g. the
+			// kro kcp-apiexport provider) reach this shard's virtual-workspace
+			// endpoints shard-direct via its VirtualWorkspaceURL, bypassing the
+			// front-proxy, so the shard itself must validate ServiceAccount
+			// tokens issued by any shard.
+			dep = utils.ApplyAuthConfigurationWithServiceAccount(dep, rootShard.Spec.Auth, rootShard)
 
 			// If rootshard has bundle annotation, store desired replicas in annotation then scale deployment to 0 locally
 			if rootShard.Annotations != nil && rootShard.Annotations[resources.BundleAnnotation] != "" {

--- a/internal/resources/rootshard/deployment.go
+++ b/internal/resources/rootshard/deployment.go
@@ -204,11 +204,6 @@ func DeploymentReconciler(rootShard *operatorv1alpha1.RootShard, kcpVW *operator
 			dep = utils.ApplyCommonShardDeploymentProperties(dep)
 			dep = utils.ApplyCommonShardConfig(dep, &rootShard.Spec.CommonShardSpec)
 			dep = utils.ApplyDeploymentTemplate(dep, rootShard.Spec.DeploymentTemplate)
-			// Use the ServiceAccount-aware variant: external clients (e.g. the
-			// kro kcp-apiexport provider) reach this shard's virtual-workspace
-			// endpoints shard-direct via its VirtualWorkspaceURL, bypassing the
-			// front-proxy, so the shard itself must validate ServiceAccount
-			// tokens issued by any shard.
 			dep = utils.ApplyAuthConfiguration(dep, rootShard.Spec.Auth, rootShard)
 
 			// If rootshard has bundle annotation, store desired replicas in annotation then scale deployment to 0 locally

--- a/internal/resources/rootshard/deployment.go
+++ b/internal/resources/rootshard/deployment.go
@@ -244,6 +244,16 @@ func getArgs(rootShard *operatorv1alpha1.RootShard, kcpVW *operatorv1alpha1.Virt
 		fmt.Sprintf("--service-account-private-key-file=%s/tls.key", getCertificateMountPath(operatorv1alpha1.ServiceAccountCertificate)),
 		"--service-account-lookup=false",
 
+		// Client certificate used by the shard to forward requests to virtual
+		// workspace endpoints (e.g. CachedResource replication VWs). Required for
+		// both embedded and external virtual workspaces: the advertised endpoint
+		// URL is the shard's external, SNI-routed VirtualWorkspaceURL, which the
+		// loopback client config cannot reach (loopback bearer token is rejected
+		// and the loopback ServerName breaks SNI routing). Set unconditionally,
+		// matching the non-root shard deployment.
+		fmt.Sprintf("--shard-client-key-file=%s/tls.key", getCertificateMountPath(operatorv1alpha1.ClientCertificate)),
+		fmt.Sprintf("--shard-client-cert-file=%s/tls.crt", getCertificateMountPath(operatorv1alpha1.ClientCertificate)),
+
 		// General shard configuration.
 		fmt.Sprintf("--shard-base-url=%s", resources.GetRootShardBaseURL(rootShard)),
 		fmt.Sprintf("--shard-external-url=https://%s:%d", rootShard.Spec.External.Hostname, rootShard.Spec.External.Port),
@@ -270,10 +280,6 @@ func getArgs(rootShard *operatorv1alpha1.RootShard, kcpVW *operatorv1alpha1.Virt
 			"--run-virtual-workspaces=false",
 			fmt.Sprintf("--shard-virtual-workspace-url=https://%s:%d", kcpVW.Spec.External.Hostname, kcpVW.Spec.External.Port),
 			fmt.Sprintf("--shard-virtual-workspace-ca-file=%s/tls.crt", getCAMountPath(operatorv1alpha1.ServerCA)),
-
-			// these two become mandatory when the in-process VW server is disabled
-			fmt.Sprintf("--shard-client-key-file=%s/tls.key", getCertificateMountPath(operatorv1alpha1.ClientCertificate)),
-			fmt.Sprintf("--shard-client-cert-file=%s/tls.crt", getCertificateMountPath(operatorv1alpha1.ClientCertificate)),
 		)
 	}
 

--- a/internal/resources/rootshard/deployment_test.go
+++ b/internal/resources/rootshard/deployment_test.go
@@ -139,6 +139,35 @@ func TestDeploymentReconciler(t *testing.T) {
 				assert.Contains(t, container.Args, "--authentication-token-webhook-config-file=/etc/kcp/authentication/webhook/kubeconfig")
 			},
 		},
+		{
+			name: "serviceAccount auth loads every shard's signing key",
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rooty",
+				},
+				Spec: operatorv1alpha1.RootShardSpec{
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						Auth: &operatorv1alpha1.AuthSpec{
+							ServiceAccount: &operatorv1alpha1.ServiceAccountAuthentication{Enabled: true},
+						},
+					},
+				},
+				Status: operatorv1alpha1.RootShardStatus{
+					Shards: []operatorv1alpha1.ShardReference{{Name: "theseus"}},
+				},
+			},
+			expectedName: resources.GetRootShardDeploymentName(&operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{Name: "rooty"},
+			}),
+			validateDeploy: func(t *testing.T, dep *appsv1.Deployment) {
+				container := dep.Spec.Template.Spec.Containers[0]
+				// The root shard must be able to validate ServiceAccount tokens
+				// issued by ANY shard, because external clients reach its virtual
+				// workspace endpoints shard-direct (bypassing the front-proxy).
+				assert.Contains(t, container.Args, "--service-account-key-file=/etc/kcp/tls/rooty/service-account/tls.crt")
+				assert.Contains(t, container.Args, "--service-account-key-file=/etc/kcp/tls/theseus/service-account/tls.crt")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/resources/rootshard/deployment_test.go
+++ b/internal/resources/rootshard/deployment_test.go
@@ -75,6 +75,14 @@ func TestDeploymentReconciler(t *testing.T) {
 					assert.True(t, volumeMountNames[expectedMount], "Expected volume mount %s not found", expectedMount)
 				}
 
+				// The shard client certificate flags must be set even with an
+				// embedded virtual workspace (kcpVW == nil here): the shard
+				// forwards CachedResource requests to its own external,
+				// SNI-routed VirtualWorkspaceURL and cannot use the loopback
+				// client config for that.
+				assert.Contains(t, container.Args, "--shard-client-cert-file=/etc/kcp/tls/client/tls.crt")
+				assert.Contains(t, container.Args, "--shard-client-key-file=/etc/kcp/tls/client/tls.key")
+
 				// Check readiness probe
 				assert.NotNil(t, container.ReadinessProbe)
 				assert.Equal(t, "/readyz", container.ReadinessProbe.HTTPGet.Path)

--- a/internal/resources/shard/deployment.go
+++ b/internal/resources/shard/deployment.go
@@ -219,7 +219,7 @@ func DeploymentReconciler(shard *operatorv1alpha1.Shard, rootShard *operatorv1al
 			// shard's virtual-workspace endpoints shard-direct via its
 			// VirtualWorkspaceURL, bypassing the front-proxy, so the shard
 			// itself must validate ServiceAccount tokens issued by any shard.
-			dep = utils.ApplyAuthConfigurationWithServiceAccount(dep, shard.Spec.Auth, rootShard)
+			dep = utils.ApplyAuthConfiguration(dep, shard.Spec.Auth, rootShard)
 
 			// If shard has bundle annotation, store desired replicas in annotation then scale deployment to 0 locally
 			if shard.Annotations != nil && shard.Annotations[resources.BundleAnnotation] != "" {

--- a/internal/resources/shard/deployment.go
+++ b/internal/resources/shard/deployment.go
@@ -215,7 +215,11 @@ func DeploymentReconciler(shard *operatorv1alpha1.Shard, rootShard *operatorv1al
 			dep = utils.ApplyCommonShardDeploymentProperties(dep)
 			dep = utils.ApplyCommonShardConfig(dep, &shard.Spec.CommonShardSpec)
 			dep = utils.ApplyDeploymentTemplate(dep, shard.Spec.DeploymentTemplate)
-			dep = utils.ApplyAuthConfiguration(dep, shard.Spec.Auth)
+			// Use the ServiceAccount-aware variant: external clients reach this
+			// shard's virtual-workspace endpoints shard-direct via its
+			// VirtualWorkspaceURL, bypassing the front-proxy, so the shard
+			// itself must validate ServiceAccount tokens issued by any shard.
+			dep = utils.ApplyAuthConfigurationWithServiceAccount(dep, shard.Spec.Auth, rootShard)
 
 			// If shard has bundle annotation, store desired replicas in annotation then scale deployment to 0 locally
 			if shard.Annotations != nil && shard.Annotations[resources.BundleAnnotation] != "" {

--- a/internal/resources/shard/deployment.go
+++ b/internal/resources/shard/deployment.go
@@ -215,10 +215,6 @@ func DeploymentReconciler(shard *operatorv1alpha1.Shard, rootShard *operatorv1al
 			dep = utils.ApplyCommonShardDeploymentProperties(dep)
 			dep = utils.ApplyCommonShardConfig(dep, &shard.Spec.CommonShardSpec)
 			dep = utils.ApplyDeploymentTemplate(dep, shard.Spec.DeploymentTemplate)
-			// Use the ServiceAccount-aware variant: external clients reach this
-			// shard's virtual-workspace endpoints shard-direct via its
-			// VirtualWorkspaceURL, bypassing the front-proxy, so the shard
-			// itself must validate ServiceAccount tokens issued by any shard.
 			dep = utils.ApplyAuthConfiguration(dep, shard.Spec.Auth, rootShard)
 
 			// If shard has bundle annotation, store desired replicas in annotation then scale deployment to 0 locally

--- a/internal/resources/utils/authentication_test.go
+++ b/internal/resources/utils/authentication_test.go
@@ -637,7 +637,7 @@ func TestApplyFrontProxyAuthConfiguration(t *testing.T) {
 	}
 
 	t.Run("token auth file is applied", func(t *testing.T) {
-		dep := ApplyFrontProxyAuthConfiguration(newDeploy(), &operatorv1alpha1.AuthSpec{
+		dep := ApplyAuthConfigurationWithServiceAccount(newDeploy(), &operatorv1alpha1.AuthSpec{
 			TokenAuthFile: &operatorv1alpha1.TokenAuthFileSpec{SecretName: "test-token-auth"},
 		}, rootShard)
 

--- a/internal/resources/utils/authentication_test.go
+++ b/internal/resources/utils/authentication_test.go
@@ -598,7 +598,7 @@ func TestApplyWebhookAuthentication(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := applyAuthConfiguration(tt.initialDeploy, tt.authenticationSpec)
+			result := ApplyAuthConfiguration(tt.initialDeploy, tt.authenticationSpec, nil)
 
 			require.NotNil(t, result)
 			assert.Equal(t, tt.initialDeploy, result, "Function should return the same deployment instance")
@@ -637,7 +637,7 @@ func TestApplyFrontProxyAuthConfiguration(t *testing.T) {
 	}
 
 	t.Run("token auth file is applied", func(t *testing.T) {
-		dep := ApplyAuthConfigurationWithServiceAccount(newDeploy(), &operatorv1alpha1.AuthSpec{
+		dep := ApplyAuthConfiguration(newDeploy(), &operatorv1alpha1.AuthSpec{
 			TokenAuthFile: &operatorv1alpha1.TokenAuthFileSpec{SecretName: "test-token-auth"},
 		}, rootShard)
 

--- a/internal/resources/utils/authentication_test.go
+++ b/internal/resources/utils/authentication_test.go
@@ -598,7 +598,7 @@ func TestApplyWebhookAuthentication(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ApplyAuthConfiguration(tt.initialDeploy, tt.authenticationSpec)
+			result := applyAuthConfiguration(tt.initialDeploy, tt.authenticationSpec)
 
 			require.NotNil(t, result)
 			assert.Equal(t, tt.initialDeploy, result, "Function should return the same deployment instance")

--- a/internal/resources/utils/deployments.go
+++ b/internal/resources/utils/deployments.go
@@ -92,7 +92,13 @@ func ApplyResources(container corev1.Container, resources *corev1.ResourceRequir
 	return container
 }
 
-func applyAuthConfiguration(deployment *appsv1.Deployment, config *operatorv1alpha1.AuthSpec) *appsv1.Deployment {
+// ApplyAuthConfiguration applies the auth configuration to a deployment,
+// including ServiceAccount authentication, which loads every shard's
+// service-account public key (see applyServiceAccountAuthentication). Components
+// that external clients authenticate against directly — the front-proxy AND the
+// shards (whose virtual-workspace endpoint URLs are reached shard-direct) — must
+// validate ServiceAccount tokens issued by any shard.
+func ApplyAuthConfiguration(deployment *appsv1.Deployment, config *operatorv1alpha1.AuthSpec, rootShard *operatorv1alpha1.RootShard) *appsv1.Deployment {
 	if config == nil {
 		return deployment
 	}
@@ -108,21 +114,6 @@ func applyAuthConfiguration(deployment *appsv1.Deployment, config *operatorv1alp
 	if config.TokenAuthFile != nil {
 		deployment = applyTokenAuthFile(deployment, *config.TokenAuthFile)
 	}
-
-	return deployment
-}
-
-// ApplyAuthConfigurationWithServiceAccount applies the common auth configuration
-// plus ServiceAccount authentication, which loads every shard's service-account
-// public key (see applyServiceAccountAuthentication). Components that external
-// clients authenticate against directly — the front-proxy AND the shards (whose
-// virtual-workspace endpoint URLs are reached shard-direct) — must validate
-// ServiceAccount tokens issued by any shard, so they all use this variant.
-func ApplyAuthConfigurationWithServiceAccount(deployment *appsv1.Deployment, config *operatorv1alpha1.AuthSpec, rootShard *operatorv1alpha1.RootShard) *appsv1.Deployment {
-	if config == nil {
-		return deployment
-	}
-	deployment = applyAuthConfiguration(deployment, config)
 
 	if config.ServiceAccount != nil && config.ServiceAccount.Enabled {
 		deployment = applyServiceAccountAuthentication(deployment, rootShard)

--- a/internal/resources/utils/deployments.go
+++ b/internal/resources/utils/deployments.go
@@ -112,7 +112,13 @@ func ApplyAuthConfiguration(deployment *appsv1.Deployment, config *operatorv1alp
 	return deployment
 }
 
-func ApplyFrontProxyAuthConfiguration(deployment *appsv1.Deployment, config *operatorv1alpha1.AuthSpec, rootShard *operatorv1alpha1.RootShard) *appsv1.Deployment {
+// ApplyAuthConfigurationWithServiceAccount applies the common auth configuration
+// plus ServiceAccount authentication, which loads every shard's service-account
+// public key (see applyServiceAccountAuthentication). Components that external
+// clients authenticate against directly — the front-proxy AND the shards (whose
+// virtual-workspace endpoint URLs are reached shard-direct) — must validate
+// ServiceAccount tokens issued by any shard, so they all use this variant.
+func ApplyAuthConfigurationWithServiceAccount(deployment *appsv1.Deployment, config *operatorv1alpha1.AuthSpec, rootShard *operatorv1alpha1.RootShard) *appsv1.Deployment {
 	if config == nil {
 		return deployment
 	}

--- a/internal/resources/utils/deployments.go
+++ b/internal/resources/utils/deployments.go
@@ -94,10 +94,7 @@ func ApplyResources(container corev1.Container, resources *corev1.ResourceRequir
 
 // ApplyAuthConfiguration applies the auth configuration to a deployment,
 // including ServiceAccount authentication, which loads every shard's
-// service-account public key (see applyServiceAccountAuthentication). Components
-// that external clients authenticate against directly — the front-proxy AND the
-// shards (whose virtual-workspace endpoint URLs are reached shard-direct) — must
-// validate ServiceAccount tokens issued by any shard.
+// service-account public key.
 func ApplyAuthConfiguration(deployment *appsv1.Deployment, config *operatorv1alpha1.AuthSpec, rootShard *operatorv1alpha1.RootShard) *appsv1.Deployment {
 	if config == nil {
 		return deployment

--- a/internal/resources/utils/deployments.go
+++ b/internal/resources/utils/deployments.go
@@ -92,7 +92,7 @@ func ApplyResources(container corev1.Container, resources *corev1.ResourceRequir
 	return container
 }
 
-func ApplyAuthConfiguration(deployment *appsv1.Deployment, config *operatorv1alpha1.AuthSpec) *appsv1.Deployment {
+func applyAuthConfiguration(deployment *appsv1.Deployment, config *operatorv1alpha1.AuthSpec) *appsv1.Deployment {
 	if config == nil {
 		return deployment
 	}
@@ -122,7 +122,7 @@ func ApplyAuthConfigurationWithServiceAccount(deployment *appsv1.Deployment, con
 	if config == nil {
 		return deployment
 	}
-	deployment = ApplyAuthConfiguration(deployment, config)
+	deployment = applyAuthConfiguration(deployment, config)
 
 	if config.ServiceAccount != nil && config.ServiceAccount.Enabled {
 		deployment = applyServiceAccountAuthentication(deployment, rootShard)


### PR DESCRIPTION
## Summary

When virtual workspaces run embedded in the shard (the default, `--run-virtual-workspaces` unset), external clients reach a shard's virtual-workspace endpoints at that shard's own external, SNI-routed `VirtualWorkspaceURL` — directly, bypassing the front-proxy. Two things broke on that shard-direct path:

**1. Shard client certificate is required on the root shard (not only for external VWs).**
The shard forwards virtual-resource requests (e.g. CachedResource replication VWs) to its advertised external URL. Without `--shard-client-cert-file`/`--shard-client-key-file` it falls back to the loopback client config, whose loopback ServerName the ingress cannot SNI-route (the connection is reset) and whose bearer token is not valid externally. The operator already set these flags unconditionally for regular `Shard`s, but for the `RootShard` only inside the external-VW branch (`kcpVW != nil`). They are now set unconditionally on the root shard too. The `ClientCertificate` is already provisioned and mounted, so only the flags were missing.

**2. ServiceAccount tokens must be validatable cross-shard on every shard, not only the front-proxy.**
ServiceAccount signing keys are per-shard. An external client (e.g. the kro `kcp-apiexport` provider) that authenticates with a ServiceAccount token minted on shard A but connects shard-direct to shard B's virtual-workspace endpoint was rejected with `401` because shard B only had its own signing key. `auth.serviceAccount.enabled` loads every shard's signing key — but the operator only wired this into the front-proxy (`ApplyFrontProxyAuthConfiguration` → `applyServiceAccountAuthentication`); the shard and rootshard deployments used `ApplyAuthConfiguration`, which ignores the `ServiceAccount` config. The shared helper is renamed to `ApplyAuthConfigurationWithServiceAccount` and is now applied to the shard and rootshard deployments as well, so any shard can validate ServiceAccount tokens issued by any shard when ServiceAccount authentication is enabled.

Both were verified end-to-end on a 2-shard (root + theseus) embedded-VW setup: cross-shard `kubectl get` of a CachedResource-backed virtual resource resolves, and a provider connecting shard-direct with a ServiceAccount token issued on another shard is no longer rejected with 401.

## What Type of PR Is This?

/kind bug

## Related Issue(s)
Fixes #

## Release Notes
```release-note
Embedded virtual workspaces: always set the shard client certificate flags on the root shard, and (when ServiceAccount authentication is enabled) load every shard's ServiceAccount signing key on all shards — not just the front-proxy — so ServiceAccount tokens issued on one shard are accepted at another shard's virtual-workspace endpoint.
```
