### PR TITLE
[release-0.7] Wire requestheader-* and mount-proxy-* flags

### DIFF
--- a/internal/controller/shard/controller.go
+++ b/internal/controller/shard/controller.go
@@ -189,6 +189,7 @@ func (r *ShardReconciler) reconcile(ctx context.Context, s *operatorv1alpha1.Sha
 		shard.ServiceAccountCertificateReconciler(s, rootShard),
 		shard.VirtualWorkspacesCertificateReconciler(s, rootShard),
 		shard.RootShardClientCertificateReconciler(s, rootShard),
+		shard.MountsProxyClientCertificateReconciler(s, rootShard),
 		shard.LogicalClusterAdminCertificateReconciler(s, rootShard),
 		shard.ExternalLogicalClusterAdminCertificateReconciler(s, rootShard),
 	}

--- a/internal/resources/frontproxy/deployment.go
+++ b/internal/resources/frontproxy/deployment.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"k8c.io/reconciler/pkg/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -69,8 +70,8 @@ func (r *reconciler) deploymentReconciler() reconciling.NamedDeploymentReconcile
 			}
 			dep.Spec.Template.SetLabels(r.resourceLabels)
 
-			image, _, _ := resources.GetImageSettings(imageSpec)
-			args := r.getArgs()
+			image, _, version := resources.GetImageSettings(imageSpec)
+			args := r.getArgs(version)
 
 			container := corev1.Container{
 				Name:    "kcp-front-proxy",
@@ -170,6 +171,13 @@ func (r *reconciler) deploymentReconciler() reconciling.NamedDeploymentReconcile
 			// kcp rootshard root ca
 			mountSecret(resources.GetRootShardCAName(r.rootShard, operatorv1alpha1.RootCA), kcpBasepath+"/tls/ca", true)
 
+			// requestheader CA, used to verify clients (e.g. a shard's mounts proxy) that
+			// re-enter the front-proxy and assert identity via X-Remote-* headers. Only mount
+			// it for kcp versions that support the mount-proxy re-entry flow.
+			if supportsMountProxy(version) {
+				mountSecret(resources.GetRootShardCAName(r.rootShard, operatorv1alpha1.RequestHeaderClientCA), getCAMountPath(operatorv1alpha1.RequestHeaderClientCA), true)
+			}
+
 			// If caBundleSecretRef is specified, mount the merged CA bundle secret.
 			// This secret contains both kcp root CA and user-provided CA bundle merged together.
 			if r.getCABundleSecretRef() != nil {
@@ -259,10 +267,30 @@ var defaultArgs = []string{
 	"--mapping-file=/etc/kcp-front-proxy/config/path-mapping.yaml",
 }
 
-func (r *reconciler) getArgs() []string {
+func supportsMountProxy(version *semver.Version) bool {
+	if version == nil {
+		return true
+	}
+
+	constraint, _ := semver.NewConstraint("~0.31.6 || >=0.32.3")
+
+	return constraint.Check(version)
+}
+
+func (r *reconciler) getArgs(version *semver.Version) []string {
 	args := defaultArgs
 
 	args = append(args, fmt.Sprintf("--client-ca-file=%s/client-ca/tls.crt", frontProxyBasepath))
+
+	if supportsMountProxy(version) {
+		args = append(args,
+			fmt.Sprintf("--requestheader-client-ca-file=%s/tls.crt", getCAMountPath(operatorv1alpha1.RequestHeaderClientCA)),
+			fmt.Sprintf("--requestheader-allowed-names=%s,%s", r.certCommonName(), resources.MountsProxyCommonName),
+			"--requestheader-username-headers=X-Remote-User",
+			"--requestheader-group-headers=X-Remote-Group",
+			"--requestheader-extra-headers-prefix=X-Remote-Extra-",
+		)
+	}
 
 	// rootshard proxy mode
 	if r.frontProxy == nil {

--- a/internal/resources/frontproxy/deployment_test.go
+++ b/internal/resources/frontproxy/deployment_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -99,6 +100,44 @@ func TestDeploymentReconciler(t *testing.T) {
 				assert.NotNil(t, container.LivenessProbe)
 				assert.Equal(t, "/livez", container.LivenessProbe.HTTPGet.Path)
 				assert.Equal(t, "https", container.LivenessProbe.HTTPGet.Port.StrVal)
+			},
+		},
+		{
+			name: "new kcp version mounts requestheader CA",
+			frontProxy: &operatorv1alpha1.FrontProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-front-proxy",
+				},
+				Spec: operatorv1alpha1.FrontProxySpec{
+					RootShard: operatorv1alpha1.RootShardConfig{
+						Reference: &corev1.LocalObjectReference{
+							Name: "test-root-shard",
+						},
+					},
+					Image: &operatorv1alpha1.ImageSpec{
+						Tag: "v0.32.3",
+					},
+				},
+			},
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-root-shard",
+				},
+			},
+			expectedName: resources.GetFrontProxyDeploymentName(&operatorv1alpha1.FrontProxy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-front-proxy"},
+			}),
+			validateDeploy: func(t *testing.T, dep *appsv1.Deployment) {
+				container := dep.Spec.Template.Spec.Containers[0]
+
+				volumeMountNames := make(map[string]bool)
+				for _, vm := range container.VolumeMounts {
+					volumeMountNames[vm.Name] = true
+				}
+				assert.True(t, volumeMountNames[resources.GetRootShardCAName(&operatorv1alpha1.RootShard{ObjectMeta: metav1.ObjectMeta{Name: "test-root-shard"}}, operatorv1alpha1.RequestHeaderClientCA)], "requestheader CA should be mounted for new kcp")
+
+				assert.Contains(t, container.Args, "--requestheader-client-ca-file=/etc/kcp/tls/ca/requestheader-client/tls.crt")
+				assert.Contains(t, container.Args, "--requestheader-allowed-names=kcp-front-proxy,kcp-mounts-proxy")
 			},
 		},
 		{
@@ -493,6 +532,7 @@ func TestGetArgs(t *testing.T) {
 	tests := []struct {
 		name     string
 		spec     *operatorv1alpha1.FrontProxySpec
+		version  *semver.Version
 		expected []string
 	}{
 		{
@@ -506,6 +546,11 @@ func TestGetArgs(t *testing.T) {
 				"--tls-cert-file=/etc/kcp-front-proxy/tls/tls.crt",
 				"--mapping-file=/etc/kcp-front-proxy/config/path-mapping.yaml",
 				"--client-ca-file=/etc/kcp-front-proxy/client-ca/tls.crt",
+				"--requestheader-client-ca-file=/etc/kcp/tls/ca/requestheader-client/tls.crt",
+				"--requestheader-allowed-names=kcp-front-proxy,kcp-mounts-proxy",
+				"--requestheader-username-headers=X-Remote-User",
+				"--requestheader-group-headers=X-Remote-Group",
+				"--requestheader-extra-headers-prefix=X-Remote-Extra-",
 			},
 		},
 		{
@@ -523,6 +568,11 @@ func TestGetArgs(t *testing.T) {
 				"--tls-cert-file=/etc/kcp-front-proxy/tls/tls.crt",
 				"--mapping-file=/etc/kcp-front-proxy/config/path-mapping.yaml",
 				"--client-ca-file=/etc/kcp-front-proxy/client-ca/tls.crt",
+				"--requestheader-client-ca-file=/etc/kcp/tls/ca/requestheader-client/tls.crt",
+				"--requestheader-allowed-names=kcp-front-proxy,kcp-mounts-proxy",
+				"--requestheader-username-headers=X-Remote-User",
+				"--requestheader-group-headers=X-Remote-Group",
+				"--requestheader-extra-headers-prefix=X-Remote-Extra-",
 				"--authentication-drop-groups=\"group1,group2\"",
 			},
 		},
@@ -541,6 +591,11 @@ func TestGetArgs(t *testing.T) {
 				"--tls-cert-file=/etc/kcp-front-proxy/tls/tls.crt",
 				"--mapping-file=/etc/kcp-front-proxy/config/path-mapping.yaml",
 				"--client-ca-file=/etc/kcp-front-proxy/client-ca/tls.crt",
+				"--requestheader-client-ca-file=/etc/kcp/tls/ca/requestheader-client/tls.crt",
+				"--requestheader-allowed-names=kcp-front-proxy,kcp-mounts-proxy",
+				"--requestheader-username-headers=X-Remote-User",
+				"--requestheader-group-headers=X-Remote-Group",
+				"--requestheader-extra-headers-prefix=X-Remote-Extra-",
 				"--authentication-pass-on-groups=\"group3,group4\"",
 			},
 		},
@@ -560,8 +615,46 @@ func TestGetArgs(t *testing.T) {
 				"--tls-cert-file=/etc/kcp-front-proxy/tls/tls.crt",
 				"--mapping-file=/etc/kcp-front-proxy/config/path-mapping.yaml",
 				"--client-ca-file=/etc/kcp-front-proxy/client-ca/tls.crt",
+				"--requestheader-client-ca-file=/etc/kcp/tls/ca/requestheader-client/tls.crt",
+				"--requestheader-allowed-names=kcp-front-proxy,kcp-mounts-proxy",
+				"--requestheader-username-headers=X-Remote-User",
+				"--requestheader-group-headers=X-Remote-Group",
+				"--requestheader-extra-headers-prefix=X-Remote-Extra-",
 				"--authentication-drop-groups=\"group1\"",
 				"--authentication-pass-on-groups=\"group2\"",
+			},
+		},
+		{
+			name:    "old kcp version omits requestheader flags",
+			spec:    &operatorv1alpha1.FrontProxySpec{},
+			version: semver.MustParse("0.32.2"),
+			expected: []string{
+				"--secure-port=6443",
+				"--root-kubeconfig=/etc/kcp-front-proxy/kubeconfig/kubeconfig",
+				"--shards-kubeconfig=/etc/kcp-front-proxy/kubeconfig/kubeconfig",
+				"--tls-private-key-file=/etc/kcp-front-proxy/tls/tls.key",
+				"--tls-cert-file=/etc/kcp-front-proxy/tls/tls.crt",
+				"--mapping-file=/etc/kcp-front-proxy/config/path-mapping.yaml",
+				"--client-ca-file=/etc/kcp-front-proxy/client-ca/tls.crt",
+			},
+		},
+		{
+			name:    "backported kcp version wires requestheader flags",
+			spec:    &operatorv1alpha1.FrontProxySpec{},
+			version: semver.MustParse("0.31.6"),
+			expected: []string{
+				"--secure-port=6443",
+				"--root-kubeconfig=/etc/kcp-front-proxy/kubeconfig/kubeconfig",
+				"--shards-kubeconfig=/etc/kcp-front-proxy/kubeconfig/kubeconfig",
+				"--tls-private-key-file=/etc/kcp-front-proxy/tls/tls.key",
+				"--tls-cert-file=/etc/kcp-front-proxy/tls/tls.crt",
+				"--mapping-file=/etc/kcp-front-proxy/config/path-mapping.yaml",
+				"--client-ca-file=/etc/kcp-front-proxy/client-ca/tls.crt",
+				"--requestheader-client-ca-file=/etc/kcp/tls/ca/requestheader-client/tls.crt",
+				"--requestheader-allowed-names=kcp-front-proxy,kcp-mounts-proxy",
+				"--requestheader-username-headers=X-Remote-User",
+				"--requestheader-group-headers=X-Remote-Group",
+				"--requestheader-extra-headers-prefix=X-Remote-Extra-",
 			},
 		},
 	}
@@ -573,7 +666,7 @@ func TestGetArgs(t *testing.T) {
 				&operatorv1alpha1.RootShard{},
 			)
 
-			result := rec.getArgs()
+			result := rec.getArgs(tt.version)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -33,6 +33,10 @@ const (
 	// RootShardProxyCommonName is the CommonName used in the requestheader client certificate for a RootShard's built-in proxy.
 	RootShardProxyCommonName = "kcp-root-shard-proxy"
 
+	// MountsProxyCommonName is the CommonName used in the client certificate that a shard's
+	// local proxy presents when it re-enters the front-proxy to serve a mounted workspace.
+	MountsProxyCommonName = "kcp-mounts-proxy"
+
 	ImageRepository = "ghcr.io/kcp-dev/kcp"
 
 	// ImageTag is the default tag to be used for any kcp component.

--- a/internal/resources/shard/certificates.go
+++ b/internal/resources/shard/certificates.go
@@ -213,6 +213,49 @@ func RootShardClientCertificateReconciler(shard *operatorv1alpha1.Shard, rootSha
 	}
 }
 
+func MountsProxyClientCertificateReconciler(shard *operatorv1alpha1.Shard, rootShard *operatorv1alpha1.RootShard) reconciling.NamedCertificateReconcilerFactory {
+	const certKind = operatorv1alpha1.MountsProxyClientCertificate
+
+	name := resources.GetShardCertificateName(shard, certKind)
+	template := shard.Spec.CertificateTemplates.CertificateTemplate(certKind)
+
+	return func() (string, reconciling.CertificateReconciler) {
+		return name, func(cert *certmanagerv1.Certificate) (*certmanagerv1.Certificate, error) {
+			cert.SetLabels(resources.GetShardResourceLabels(shard))
+			cert.Spec = certmanagerv1.CertificateSpec{
+				SecretName: name,
+				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
+					Labels: map[string]string{
+						resources.RootShardLabel: rootShard.Name,
+						resources.ShardLabel:     shard.Name,
+					},
+				},
+
+				CommonName:  resources.MountsProxyCommonName,
+				Duration:    &operatorv1alpha1.DefaultCertificateDuration,
+				RenewBefore: &operatorv1alpha1.DefaultCertificateRenewal,
+
+				PrivateKey: &certmanagerv1.CertificatePrivateKey{
+					Algorithm: certmanagerv1.RSAKeyAlgorithm,
+					Size:      4096,
+				},
+
+				Usages: []certmanagerv1.KeyUsage{
+					certmanagerv1.UsageClientAuth,
+				},
+
+				IssuerRef: certmanagermetav1.ObjectReference{
+					Name:  resources.GetRootShardCAName(rootShard, operatorv1alpha1.RequestHeaderClientCA),
+					Kind:  "Issuer",
+					Group: "cert-manager.io",
+				},
+			}
+
+			return utils.ApplyCertificateTemplate(cert, &template), nil
+		}
+	}
+}
+
 func LogicalClusterAdminCertificateReconciler(shard *operatorv1alpha1.Shard, rootShard *operatorv1alpha1.RootShard) reconciling.NamedCertificateReconcilerFactory {
 	const certKind = operatorv1alpha1.LogicalClusterAdminCertificate
 

--- a/internal/resources/shard/deployment.go
+++ b/internal/resources/shard/deployment.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"k8c.io/reconciler/pkg/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -105,7 +106,9 @@ func DeploymentReconciler(shard *operatorv1alpha1.Shard, rootShard *operatorv1al
 				MountPath:  getCAMountPath(operatorv1alpha1.RootCA),
 			}}
 
-			args := getArgs(shard, rootShard, kcpVW)
+			_, _, version := resources.GetImageSettings(shard.Spec.Image)
+
+			args := getArgs(shard, rootShard, kcpVW, version)
 
 			for _, cert := range []operatorv1alpha1.Certificate{
 				// requires server CA and the shard client cert to be mounted
@@ -134,13 +137,19 @@ func DeploymentReconciler(shard *operatorv1alpha1.Shard, rootShard *operatorv1al
 				})
 			}
 
-			for _, cert := range []operatorv1alpha1.Certificate{
+			certs := []operatorv1alpha1.Certificate{
 				operatorv1alpha1.ServerCertificate,
 				operatorv1alpha1.ServiceAccountCertificate,
 				operatorv1alpha1.ClientCertificate,
 				operatorv1alpha1.LogicalClusterAdminCertificate,
 				operatorv1alpha1.ExternalLogicalClusterAdminCertificate,
-			} {
+			}
+
+			if supportsMountProxy(version) {
+				certs = append(certs, operatorv1alpha1.MountsProxyClientCertificate)
+			}
+
+			for _, cert := range certs {
 				secretMounts = append(secretMounts, utils.SecretMount{
 					VolumeName: fmt.Sprintf("%s-cert", cert),
 					SecretName: resources.GetShardCertificateName(shard, cert),
@@ -221,7 +230,17 @@ func DeploymentReconciler(shard *operatorv1alpha1.Shard, rootShard *operatorv1al
 	}
 }
 
-func getArgs(shard *operatorv1alpha1.Shard, rootShard *operatorv1alpha1.RootShard, kcpVW *operatorv1alpha1.VirtualWorkspace) []string {
+func supportsMountProxy(version *semver.Version) bool {
+	if version == nil {
+		return true
+	}
+
+	constraint, _ := semver.NewConstraint("~0.31.6 || >=0.32.3")
+
+	return constraint.Check(version)
+}
+
+func getArgs(shard *operatorv1alpha1.Shard, rootShard *operatorv1alpha1.RootShard, kcpVW *operatorv1alpha1.VirtualWorkspace, version *semver.Version) []string {
 	// Configure the cache kubeconfig to point either to an explicitly configured cache (maybe on the
 	// shard, maybe on the root shard), or the root shard itself (in case no external cache is configured).
 	var cacheKubeconfigMount string
@@ -269,6 +288,13 @@ func getArgs(shard *operatorv1alpha1.Shard, rootShard *operatorv1alpha1.RootShar
 		"--root-directory=",
 		"--enable-leader-election=true",
 		"--logging-format=json",
+	}
+
+	if supportsMountProxy(version) {
+		args = append(args,
+			fmt.Sprintf("--mount-proxy-client-cert-file=%s/tls.crt", getCertificateMountPath(operatorv1alpha1.MountsProxyClientCertificate)),
+			fmt.Sprintf("--mount-proxy-client-key-file=%s/tls.key", getCertificateMountPath(operatorv1alpha1.MountsProxyClientCertificate)),
+		)
 	}
 
 	args = append(args, utils.GetLoggingArgs(shard.Spec.Logging)...)

--- a/sdk/apis/operator/v1alpha1/common.go
+++ b/sdk/apis/operator/v1alpha1/common.go
@@ -91,6 +91,7 @@ const (
 	ServiceAccountCertificate              Certificate = "service-account"
 	VirtualWorkspacesCertificate           Certificate = "virtual-workspaces"
 	RequestHeaderClientCertificate         Certificate = "requestheader"
+	MountsProxyClientCertificate           Certificate = "mounts-proxy"
 	KubeconfigCertificate                  Certificate = "kubeconfig"
 	AdminKubeconfigClientCertificate       Certificate = "admin-kubeconfig"
 	LogicalClusterAdminCertificate         Certificate = "logical-cluster-admin"


### PR DESCRIPTION
This is a manual cherry-pick of #253

```release-note
Wire `requestheader-*` and `mount-proxy-*` flags introduced in https://github.com/kcp-dev/kcp/pull/4238
```