### PR TITLE
Add EtcdConfig.Prefix

### DIFF
--- a/config/crd/bases/operator.kcp.io_cacheservers.yaml
+++ b/config/crd/bases/operator.kcp.io_cacheservers.yaml
@@ -1580,6 +1580,11 @@ spec:
                     items:
                       type: string
                     type: array
+                  prefix:
+                    description: Prefix is the etcd key prefix under which the component
+                      stores its data. If unset, the components default prefix is
+                      used.
+                    type: string
                   tlsConfig:
                     description: ClientCert configures the client certificate used
                       to access etcd.

--- a/config/crd/bases/operator.kcp.io_rootshards.yaml
+++ b/config/crd/bases/operator.kcp.io_rootshards.yaml
@@ -1911,6 +1911,11 @@ spec:
                     items:
                       type: string
                     type: array
+                  prefix:
+                    description: Prefix is the etcd key prefix under which the component
+                      stores its data. If unset, the components default prefix is
+                      used.
+                    type: string
                   tlsConfig:
                     description: ClientCert configures the client certificate used
                       to access etcd.

--- a/config/crd/bases/operator.kcp.io_shards.yaml
+++ b/config/crd/bases/operator.kcp.io_shards.yaml
@@ -1856,6 +1856,11 @@ spec:
                     items:
                       type: string
                     type: array
+                  prefix:
+                    description: Prefix is the etcd key prefix under which the component
+                      stores its data. If unset, the components default prefix is
+                      used.
+                    type: string
                   tlsConfig:
                     description: ClientCert configures the client certificate used
                       to access etcd.

--- a/internal/resources/cacheserver/deployment.go
+++ b/internal/resources/cacheserver/deployment.go
@@ -228,6 +228,11 @@ func getArgs(server *operatorv1alpha1.CacheServer, version *semver.Version) []st
 		args = append(args,
 			fmt.Sprintf("--etcd-servers=%s", strings.Join(server.Spec.Etcd.Endpoints, ",")),
 		)
+		if server.Spec.Etcd.Prefix != "" {
+			args = append(args,
+				fmt.Sprintf("--etcd-prefix=%s", server.Spec.Etcd.Prefix),
+			)
+		}
 		if server.Spec.Etcd.TLSConfig != nil {
 			args = append(args,
 				fmt.Sprintf("--etcd-cafile=%s/ca.crt", getEtcdCertificateMountPath()),

--- a/internal/resources/cacheserver/deployment_test.go
+++ b/internal/resources/cacheserver/deployment_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cacheserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+func TestGetArgsEtcdPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		etcd   *operatorv1alpha1.EtcdConfig
+		expect func(*testing.T, []string)
+	}{
+		{
+			name: "dedicated etcd wires the prefix when set",
+			etcd: &operatorv1alpha1.EtcdConfig{
+				Endpoints: []string{"https://etcd:2379"},
+				Prefix:    "/custom-prefix",
+			},
+			expect: func(t *testing.T, args []string) {
+				assert.Contains(t, args, "--etcd-prefix=/custom-prefix")
+			},
+		},
+		{
+			name: "dedicated etcd omits the prefix when unset",
+			etcd: &operatorv1alpha1.EtcdConfig{
+				Endpoints: []string{"https://etcd:2379"},
+			},
+			expect: func(t *testing.T, args []string) {
+				for _, arg := range args {
+					assert.NotContains(t, arg, "--etcd-prefix")
+				}
+			},
+		},
+		{
+			name: "embedded etcd never wires a prefix",
+			etcd: nil,
+			expect: func(t *testing.T, args []string) {
+				for _, arg := range args {
+					assert.NotContains(t, arg, "--etcd-prefix")
+					assert.NotContains(t, arg, "--etcd-servers")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &operatorv1alpha1.CacheServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cachey"},
+				Spec:       operatorv1alpha1.CacheServerSpec{Etcd: tt.etcd},
+			}
+
+			tt.expect(t, getArgs(server, nil))
+		})
+	}
+}

--- a/internal/resources/rootshard/deployment_test.go
+++ b/internal/resources/rootshard/deployment_test.go
@@ -168,6 +168,53 @@ func TestDeploymentReconciler(t *testing.T) {
 				assert.Contains(t, container.Args, "--service-account-key-file=/etc/kcp/tls/theseus/service-account/tls.crt")
 			},
 		},
+		{
+			name: "etcd prefix is wired when set",
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rooty",
+				},
+				Spec: operatorv1alpha1.RootShardSpec{
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						Etcd: operatorv1alpha1.EtcdConfig{
+							Endpoints: []string{"https://etcd:2379"},
+							Prefix:    "/custom-prefix",
+						},
+					},
+				},
+			},
+			expectedName: resources.GetRootShardDeploymentName(&operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{Name: "rooty"},
+			}),
+			validateDeploy: func(t *testing.T, dep *appsv1.Deployment) {
+				container := dep.Spec.Template.Spec.Containers[0]
+				assert.Contains(t, container.Args, "--etcd-prefix=/custom-prefix")
+			},
+		},
+		{
+			name: "etcd prefix is omitted when unset",
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rooty",
+				},
+				Spec: operatorv1alpha1.RootShardSpec{
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						Etcd: operatorv1alpha1.EtcdConfig{
+							Endpoints: []string{"https://etcd:2379"},
+						},
+					},
+				},
+			},
+			expectedName: resources.GetRootShardDeploymentName(&operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{Name: "rooty"},
+			}),
+			validateDeploy: func(t *testing.T, dep *appsv1.Deployment) {
+				container := dep.Spec.Template.Spec.Containers[0]
+				for _, arg := range container.Args {
+					assert.NotContains(t, arg, "--etcd-prefix")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/resources/shard/deployment_test.go
+++ b/internal/resources/shard/deployment_test.go
@@ -246,6 +246,63 @@ func TestDeploymentReconciler(t *testing.T) {
 				assert.Contains(t, container.Args, "--mount-proxy-client-key-file=/etc/kcp/tls/mounts-proxy/tls.key")
 			},
 		},
+		{
+			name: "etcd prefix is wired when set",
+			shard: &operatorv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "shardy",
+				},
+				Spec: operatorv1alpha1.ShardSpec{
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						Etcd: operatorv1alpha1.EtcdConfig{
+							Endpoints: []string{"https://etcd:2379"},
+							Prefix:    "/custom-prefix",
+						},
+					},
+				},
+			},
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rooty",
+				},
+			},
+			expectedName: resources.GetShardDeploymentName(&operatorv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{Name: "shardy"},
+			}),
+			validateDeploy: func(t *testing.T, dep *appsv1.Deployment) {
+				container := dep.Spec.Template.Spec.Containers[0]
+				assert.Contains(t, container.Args, "--etcd-prefix=/custom-prefix")
+			},
+		},
+		{
+			name: "etcd prefix is omitted when unset",
+			shard: &operatorv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "shardy",
+				},
+				Spec: operatorv1alpha1.ShardSpec{
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						Etcd: operatorv1alpha1.EtcdConfig{
+							Endpoints: []string{"https://etcd:2379"},
+						},
+					},
+				},
+			},
+			rootShard: &operatorv1alpha1.RootShard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rooty",
+				},
+			},
+			expectedName: resources.GetShardDeploymentName(&operatorv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{Name: "shardy"},
+			}),
+			validateDeploy: func(t *testing.T, dep *appsv1.Deployment) {
+				container := dep.Spec.Template.Spec.Containers[0]
+				for _, arg := range container.Args {
+					assert.NotContains(t, arg, "--etcd-prefix")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/resources/utils/shard.go
+++ b/internal/resources/utils/shard.go
@@ -160,6 +160,13 @@ func applyEtcdConfiguration(deployment *appsv1.Deployment, config operatorv1alph
 		fmt.Sprintf("--etcd-servers=%s", strings.Join(config.Endpoints, ",")),
 	)
 
+	if config.Prefix != "" {
+		podSpec.Containers[0].Args = append(
+			podSpec.Containers[0].Args,
+			fmt.Sprintf("--etcd-prefix=%s", config.Prefix),
+		)
+	}
+
 	if config.TLSConfig != nil {
 		volumeName := "etcd-client-cert"
 		mountPath := "/etc/etcd/tls"

--- a/sdk/apis/operator/v1alpha1/common.go
+++ b/sdk/apis/operator/v1alpha1/common.go
@@ -51,6 +51,9 @@ type EtcdConfig struct {
 	// ClientCert configures the client certificate used to access etcd.
 	// +optional
 	TLSConfig *EtcdTLSConfig `json:"tlsConfig,omitempty"`
+	// Prefix is the etcd key prefix under which the component stores its data. If unset, the components default prefix is used.
+	// +optional
+	Prefix string `json:"prefix,omitempty"`
 }
 
 type EtcdTLSConfig struct {

--- a/sdk/applyconfiguration/operator/v1alpha1/etcdconfig.go
+++ b/sdk/applyconfiguration/operator/v1alpha1/etcdconfig.go
@@ -23,6 +23,7 @@ package v1alpha1
 type EtcdConfigApplyConfiguration struct {
 	Endpoints []string                         `json:"endpoints,omitempty"`
 	TLSConfig *EtcdTLSConfigApplyConfiguration `json:"tlsConfig,omitempty"`
+	Prefix    *string                          `json:"prefix,omitempty"`
 }
 
 // EtcdConfigApplyConfiguration constructs a declarative configuration of the EtcdConfig type for use with
@@ -46,5 +47,13 @@ func (b *EtcdConfigApplyConfiguration) WithEndpoints(values ...string) *EtcdConf
 // If called multiple times, the TLSConfig field is set to the value of the last call.
 func (b *EtcdConfigApplyConfiguration) WithTLSConfig(value *EtcdTLSConfigApplyConfiguration) *EtcdConfigApplyConfiguration {
 	b.TLSConfig = value
+	return b
+}
+
+// WithPrefix sets the Prefix field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Prefix field is set to the value of the last call.
+func (b *EtcdConfigApplyConfiguration) WithPrefix(value string) *EtcdConfigApplyConfiguration {
+	b.Prefix = &value
 	return b
 }


### PR DESCRIPTION
7<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.md.

-->

## Summary

Adds EtcdConfig.Prefix resulting in `--etcd-prefix` for kcp components.
Also added for cache-server although that needs https://github.com/kcp-dev/kcp/pull/4292 to be actually honoured :D 

<!--
Please provide a description that explains *why* your PR is changing something
in the codebase, and focus less on what *what* you're changing. The following are
good questions to ask yourself when writing the PR summary:

* What are the problems you are trying to solve?
* What assumptions did you make when implementing your changes?
* Which workflows will be affected/improved by your change?
-->

## What Type of PR Is This?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

## Related Issue(s)
Fixes #

## Release Notes
<!--
Please add a release note in the block below.
Leave NONE only if no user-facing changes are in this PR.
-->
```release-note
Support setting `--etcd-prefix` for shards and cache-server
```
