### PR TITLE
Label rendered kubeconfig Secrets with component labels

### DIFF
--- a/internal/controller/virtualworkspace/controller.go
+++ b/internal/controller/virtualworkspace/controller.go
@@ -119,9 +119,8 @@ func (r *Reconciler) reconcile(ctx context.Context, vw *operatorv1alpha1.Virtual
 	var conditions []metav1.Condition
 
 	var (
-		rootShard        *operatorv1alpha1.RootShard
-		shard            *operatorv1alpha1.Shard
-		clientCertIssuer string
+		rootShard *operatorv1alpha1.RootShard
+		shard     *operatorv1alpha1.Shard
 	)
 
 	switch {
@@ -138,9 +137,6 @@ func (r *Reconciler) reconcile(ctx context.Context, vw *operatorv1alpha1.Virtual
 			})
 			return conditions, err
 		}
-
-		clientCertIssuer = resources.GetRootShardCAName(rootShard, operatorv1alpha1.ClientCA)
-		// serverCA = resources.GetRootShardCAName(rootShard, operatorv1alpha1.ServerCA)
 
 	case vw.Spec.Target.ShardRef != nil:
 		shard = &operatorv1alpha1.Shard{}
@@ -180,10 +176,6 @@ func (r *Reconciler) reconcile(ctx context.Context, vw *operatorv1alpha1.Virtual
 			return conditions, err
 		}
 
-		// The client CA is shared among all shards and owned by the root shard.
-		clientCertIssuer = resources.GetRootShardCAName(rootShard, operatorv1alpha1.ClientCA)
-		// serverCA = resources.GetRootShardCAName(rootShard, operatorv1alpha1.ServerCA)
-
 	default:
 		err := errors.New("no valid target for VirtualWorkspace found")
 		conditions = append(conditions, metav1.Condition{
@@ -206,7 +198,7 @@ func (r *Reconciler) reconcile(ctx context.Context, vw *operatorv1alpha1.Virtual
 	revisionLabels := modifier.RelatedRevisionsLabels(ctx, r.Client)
 
 	if err := reconciling.ReconcileCertificates(ctx, []reconciling.NamedCertificateReconcilerFactory{
-		virtualworkspace.ClientCertificateReconciler(vw, clientCertIssuer),
+		virtualworkspace.ClientCertificateReconciler(vw, rootShard),
 		virtualworkspace.ServerCertificateReconciler(vw, rootShard),
 	}, vw.Namespace, r.Client, ownerRefWrapper); err != nil {
 		return conditions, err

--- a/internal/resources/cacheserver/kubeconfigs.go
+++ b/internal/resources/cacheserver/kubeconfigs.go
@@ -36,6 +36,12 @@ func KubeconfigReconciler(server *operatorv1alpha1.CacheServer) k8creconciling.N
 	return func() (string, k8creconciling.SecretReconciler) {
 		return resources.GetCacheServerKubeconfigName(server.Name), func(secret *corev1.Secret) (*corev1.Secret, error) {
 			var config *clientcmdapi.Config
+
+			if secret.Labels == nil {
+				secret.Labels = make(map[string]string)
+			}
+			secret.Labels[resources.CacheServerLabel] = server.Name
+
 			if secret.Data == nil {
 				secret.Data = make(map[string][]byte)
 			}

--- a/internal/resources/frontproxy/secrets.go
+++ b/internal/resources/frontproxy/secrets.go
@@ -44,6 +44,9 @@ func (r *reconciler) dynamicKubeconfigSecretReconciler() reconciling.NamedSecret
 	return func() (string, reconciling.SecretReconciler) {
 		return name, func(obj *corev1.Secret) (*corev1.Secret, error) {
 			obj.SetLabels(r.resourceLabels)
+			for k, v := range r.certSecretLabels() {
+				obj.Labels[k] = v
+			}
 
 			kubeconfig, err := r.dynamicKubeconfig()
 			if err != nil {

--- a/internal/resources/rootshard/kubeconfigs.go
+++ b/internal/resources/rootshard/kubeconfigs.go
@@ -44,6 +44,11 @@ func LogicalClusterAdminKubeconfigReconciler(rootShard *operatorv1alpha1.RootSha
 		return kubeconfigSecret(rootShard, operatorv1alpha1.LogicalClusterAdminCertificate), func(secret *corev1.Secret) (*corev1.Secret, error) {
 			var config *clientcmdapi.Config
 
+			if secret.Labels == nil {
+				secret.Labels = make(map[string]string)
+			}
+			secret.Labels[resources.RootShardLabel] = rootShard.Name
+
 			if secret.Data == nil {
 				secret.Data = make(map[string][]byte)
 			}
@@ -92,6 +97,11 @@ func ExternalLogicalClusterAdminKubeconfigReconciler(rootShard *operatorv1alpha1
 	return func() (string, k8creconciling.SecretReconciler) {
 		return kubeconfigSecret(rootShard, operatorv1alpha1.ExternalLogicalClusterAdminCertificate), func(secret *corev1.Secret) (*corev1.Secret, error) {
 			var config *clientcmdapi.Config
+
+			if secret.Labels == nil {
+				secret.Labels = make(map[string]string)
+			}
+			secret.Labels[resources.RootShardLabel] = rootShard.Name
 
 			if secret.Data == nil {
 				secret.Data = make(map[string][]byte)

--- a/internal/resources/shard/kubeconfigs.go
+++ b/internal/resources/shard/kubeconfigs.go
@@ -43,6 +43,13 @@ func RootShardClientKubeconfigReconciler(shard *operatorv1alpha1.Shard, rootShar
 	return func() (string, k8creconciling.SecretReconciler) {
 		return kubeconfigSecret(shard, operatorv1alpha1.ClientCertificate), func(secret *corev1.Secret) (*corev1.Secret, error) {
 			var config *clientcmdapi.Config
+
+			if secret.Labels == nil {
+				secret.Labels = make(map[string]string)
+			}
+			secret.Labels[resources.RootShardLabel] = rootShard.Name
+			secret.Labels[resources.ShardLabel] = shard.Name
+
 			if secret.Data == nil {
 				secret.Data = make(map[string][]byte)
 			}
@@ -92,6 +99,12 @@ func LogicalClusterAdminKubeconfigReconciler(shard *operatorv1alpha1.Shard, root
 		return kubeconfigSecret(shard, operatorv1alpha1.LogicalClusterAdminCertificate), func(secret *corev1.Secret) (*corev1.Secret, error) {
 			var config *clientcmdapi.Config
 
+			if secret.Labels == nil {
+				secret.Labels = make(map[string]string)
+			}
+			secret.Labels[resources.RootShardLabel] = rootShard.Name
+			secret.Labels[resources.ShardLabel] = shard.Name
+
 			if secret.Data == nil {
 				secret.Data = make(map[string][]byte)
 			}
@@ -140,6 +153,12 @@ func ExternalLogicalClusterAdminKubeconfigReconciler(shard *operatorv1alpha1.Sha
 	return func() (string, k8creconciling.SecretReconciler) {
 		return kubeconfigSecret(shard, operatorv1alpha1.ExternalLogicalClusterAdminCertificate), func(secret *corev1.Secret) (*corev1.Secret, error) {
 			var config *clientcmdapi.Config
+
+			if secret.Labels == nil {
+				secret.Labels = make(map[string]string)
+			}
+			secret.Labels[resources.RootShardLabel] = rootShard.Name
+			secret.Labels[resources.ShardLabel] = shard.Name
 
 			if secret.Data == nil {
 				secret.Data = make(map[string][]byte)

--- a/internal/resources/virtualworkspace/ca_bundle.go
+++ b/internal/resources/virtualworkspace/ca_bundle.go
@@ -71,6 +71,7 @@ func MergedClientCABundleSecretReconciler(ctx context.Context, vw *operatorv1alp
 			if secret.Labels == nil {
 				secret.Labels = make(map[string]string)
 			}
+			secret.Labels[resources.RootShardLabel] = rootShard.Name
 			secret.Labels[resources.VirtualWorkspaceLabel] = vw.Name
 
 			return secret, nil

--- a/internal/resources/virtualworkspace/certificate.go
+++ b/internal/resources/virtualworkspace/certificate.go
@@ -32,7 +32,7 @@ func commonName(vw *operatorv1alpha1.VirtualWorkspace) string {
 	return fmt.Sprintf("%s-virtual-workspace", vw.Name)
 }
 
-func ClientCertificateReconciler(vw *operatorv1alpha1.VirtualWorkspace, issuerName string) reconciling.NamedCertificateReconcilerFactory {
+func ClientCertificateReconciler(vw *operatorv1alpha1.VirtualWorkspace, rootShard *operatorv1alpha1.RootShard) reconciling.NamedCertificateReconcilerFactory {
 	const certKind = operatorv1alpha1.ClientCertificate
 
 	template := vw.Spec.CertificateTemplates.CertificateTemplate(certKind)
@@ -45,6 +45,7 @@ func ClientCertificateReconciler(vw *operatorv1alpha1.VirtualWorkspace, issuerNa
 				SecretName: name,
 				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
 					Labels: map[string]string{
+						resources.RootShardLabel:        rootShard.Name,
 						resources.VirtualWorkspaceLabel: vw.Name,
 					},
 				},
@@ -69,7 +70,7 @@ func ClientCertificateReconciler(vw *operatorv1alpha1.VirtualWorkspace, issuerNa
 				},
 
 				IssuerRef: certmanagermetav1.IssuerReference{
-					Name:  issuerName,
+					Name:  resources.GetRootShardCAName(rootShard, operatorv1alpha1.ClientCA),
 					Kind:  "Issuer",
 					Group: "cert-manager.io",
 				},
@@ -93,6 +94,7 @@ func ServerCertificateReconciler(vw *operatorv1alpha1.VirtualWorkspace, rootShar
 				SecretName: name,
 				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
 					Labels: map[string]string{
+						resources.RootShardLabel:        rootShard.Name,
 						resources.VirtualWorkspaceLabel: vw.Name,
 					},
 				},


### PR DESCRIPTION
This PR is part of a stacked PR that splits kcp-operator's functionality
into two controller groups, `config` and `workload` and adds an
intermediate resource group deploy.operator.kcp.io. The config
controller group prepares and compiles resources into resources of the
group deploy.operator.kcp.io.

The `workload` then realizes the compiled resource into workload
resources (`Deployment` and `Service`).

```release-note
New labels identifying the components to Kubeconfigs and Secrets
```

/kind feature