### PR TITLE
Add --enabled-controller-groups flag to toggle controller groups

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -31,9 +31,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -81,6 +83,7 @@ func run(ctx context.Context) error {
 	var (
 		metricsAddr, probeAddr                           string
 		enableLeaderElection, secureMetrics, enableHTTP2 bool
+		enabledControllerGroups                          []string
 		tlsOpts                                          []func(*tls.Config)
 	)
 
@@ -97,6 +100,9 @@ func run(ctx context.Context) error {
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 	fs.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	fs.StringSliceVar(&enabledControllerGroups, "enabled-controller-groups",
+		[]string{string(config.ControllerGroupConfig), string(config.ControllerGroupWorkload)},
+		"Comma-separated list of controller groups to enable (available: config, workload).")
 
 	// Add feature gates flag
 	config.DefaultMutableFeatureGate.AddFlag(fs)
@@ -117,6 +123,12 @@ func run(ctx context.Context) error {
 
 	// Log enabled feature gates
 	setupLog.Info("Feature gates", "gates", config.DefaultFeatureGate)
+
+	controllerGroups, err := config.ParseControllerGroups(enabledControllerGroups)
+	if err != nil {
+		return fmt.Errorf("invalid --enabled-controller-groups: %w", err)
+	}
+	setupLog.Info("Enabled controller groups", "groups", sets.List(controllerGroups))
 
 	log := zap.NewRaw(zap.UseFlagOptions(&opts))
 	ctrl.SetLogger(zapr.NewLogger(log))
@@ -190,56 +202,10 @@ func run(ctx context.Context) error {
 
 	client := mgr.GetClient()
 
-	if err = (&rootshard.RootShardReconciler{
-		Client: client,
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create controller %s: %w", "RootShard", err)
-	}
-	if err = (&frontproxy.FrontProxyReconciler{
-		Client: client,
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create controller %s: %w", "FrontProxy", err)
-	}
-	if err = (&shard.ShardReconciler{
-		Client: client,
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create controller %s: %w", "Shard", err)
-	}
-	if err = (&cacheserver.CacheServerReconciler{
-		Client: client,
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create controller %s: %w", "CacheServer", err)
-	}
-	if err = (&kubeconfig.KubeconfigReconciler{
-		Client: client,
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create controller %s: %w", "Kubeconfig", err)
-	}
-	if err = (&virtualworkspace.Reconciler{
-		Client: client,
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create controller %s: %w", "VirtualWorkspace", err)
-	}
-	if config.Enabled(config.ConfigurationBundle) {
-		if err = (&bundle.BundleReconciler{
-			Client: client,
-			Scheme: mgr.GetScheme(),
-		}).SetupWithManager(mgr); err != nil {
-			return fmt.Errorf("unable to create controller %s: %w", "Bundle", err)
+	if controllerGroups.Has(config.ControllerGroupConfig) {
+		if err := setupConfigControllers(mgr, client); err != nil {
+			return err
 		}
-	}
-	if err = (&kubeconfigrbac.KubeconfigRBACReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "KubeconfigRBAC")
-		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder
 
@@ -257,4 +223,59 @@ func run(ctx context.Context) error {
 
 	setupLog.Info("starting manager")
 	return mgr.Start(ctx)
+}
+
+func setupConfigControllers(mgr ctrl.Manager, client ctrlruntimeclient.Client) error {
+	if err := (&rootshard.RootShardReconciler{
+		Client: client,
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "RootShard", err)
+	}
+	if err := (&frontproxy.FrontProxyReconciler{
+		Client: client,
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "FrontProxy", err)
+	}
+	if err := (&shard.ShardReconciler{
+		Client: client,
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "Shard", err)
+	}
+	if err := (&cacheserver.CacheServerReconciler{
+		Client: client,
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "CacheServer", err)
+	}
+	if err := (&kubeconfig.KubeconfigReconciler{
+		Client: client,
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "Kubeconfig", err)
+	}
+	if err := (&virtualworkspace.Reconciler{
+		Client: client,
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "VirtualWorkspace", err)
+	}
+	if config.Enabled(config.ConfigurationBundle) {
+		if err := (&bundle.BundleReconciler{
+			Client: client,
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to create controller %s: %w", "Bundle", err)
+		}
+	}
+	if err := (&kubeconfigrbac.KubeconfigRBACReconciler{
+		Client: client,
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "KubeconfigRBAC", err)
+	}
+
+	return nil
 }

--- a/internal/config/controllergroups.go
+++ b/internal/config/controllergroups.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// ControllerGroup is a group of controllers that can be enabled or disabled together.
+type ControllerGroup string
+
+const (
+	// ControllerGroupConfig groups controllers that are configuring a kcp instance.
+	// This includes orchestrating cert-manager resources and compiling the workload CRs.
+	ControllerGroupConfig ControllerGroup = "config"
+
+	// ControllerGroupWorkload groups controllers that deploy the compiled workload CRs
+	// into compute resources like Deployments and Services.
+	ControllerGroupWorkload ControllerGroup = "workload"
+)
+
+// AllControllerGroups returns a new set containing all known controller groups.
+func AllControllerGroups() sets.Set[ControllerGroup] {
+	return sets.New(ControllerGroupConfig, ControllerGroupWorkload)
+}
+
+// ParseControllerGroups validates the given controller group names and returns them as a set.
+// Unknown names or an empty list result in an error.
+func ParseControllerGroups(names []string) (sets.Set[ControllerGroup], error) {
+	known := AllControllerGroups()
+
+	parsed := sets.New[ControllerGroup]()
+	for _, name := range names {
+		group := ControllerGroup(strings.TrimSpace(name))
+		if !known.Has(group) {
+			return nil, fmt.Errorf("unknown controller group %q, known controller groups are %v", name, sets.List(known))
+		}
+		parsed.Insert(group)
+	}
+
+	if parsed.Len() == 0 {
+		return nil, fmt.Errorf("at least one controller group must be enabled, known controller groups are %v", sets.List(known))
+	}
+
+	return parsed, nil
+}

--- a/internal/config/controllergroups_test.go
+++ b/internal/config/controllergroups_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestParseControllerGroups(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected sets.Set[ControllerGroup]
+		wantErr  bool
+	}{
+		{
+			name:     "all groups",
+			input:    []string{"config", "workload"},
+			expected: sets.New(ControllerGroupConfig, ControllerGroupWorkload),
+		},
+		{
+			name:     "config only",
+			input:    []string{"config"},
+			expected: sets.New(ControllerGroupConfig),
+		},
+		{
+			name:     "workload only",
+			input:    []string{"workload"},
+			expected: sets.New(ControllerGroupWorkload),
+		},
+		{
+			name:     "duplicates are collapsed",
+			input:    []string{"config", "config"},
+			expected: sets.New(ControllerGroupConfig),
+		},
+		{
+			name:     "whitespace is trimmed",
+			input:    []string{" config ", "workload"},
+			expected: sets.New(ControllerGroupConfig, ControllerGroupWorkload),
+		},
+		{
+			name:    "unknown group",
+			input:   []string{"config", "bogus"},
+			wantErr: true,
+		},
+		{
+			name:    "empty list",
+			input:   []string{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := ParseControllerGroups(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", parsed)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !parsed.Equal(tt.expected) {
+				t.Errorf("expected %v, got %v", sets.List(tt.expected), sets.List(parsed))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR is part of a stacked PR that splits kcp-operator's functionality
into two controller groups, `config` and `workload` and adds an
intermediate resource group deploy.operator.kcp.io. The config
controller group prepares and compiles resources into resources of the
group deploy.operator.kcp.io.

The `workload` then realizes the compiled resource into workload
resources (`Deployment` and `Service`).

```release-note
NONE
```

/kind feature
