### PR TITLE
Compile admin resources into deploy.operator.kcp.io CRs

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/kcp-dev/kcp-operator/internal/controller/virtualworkspace"
 	"github.com/kcp-dev/kcp-operator/internal/metrics"
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -65,6 +66,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(deployv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(certmanagerv1.AddToScheme(scheme))
 	utilruntime.Must(kcpcorev1alpha1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -44,6 +44,22 @@ rules:
   - update
   - watch
 - apiGroups:
+  - deploy.operator.kcp.io
+  resources:
+  - compiledcacheservers
+  - compiledfrontproxies
+  - compiledrootshards
+  - compiledshards
+  - compiledvirtualworkspaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - operator.kcp.io
   resources:
   - bundles

--- a/hack/reconciling.yaml
+++ b/hack/reconciling.yaml
@@ -24,6 +24,12 @@ resourceTypes:
   - { package: github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1, resourceName: CacheServer }
   - { package: github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1, resourceName: FrontProxy }
   - { package: github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1, resourceName: Kubeconfig }
+  # deploy.operator.kcp.io/v1alpha1
+  - { package: github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1, resourceName: CompiledRootShard }
+  - { package: github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1, resourceName: CompiledShard }
+  - { package: github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1, resourceName: CompiledCacheServer }
+  - { package: github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1, resourceName: CompiledFrontProxy }
+  - { package: github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1, resourceName: CompiledVirtualWorkspace }
   # cert-manager.io/v1
   - { package: github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1, resourceName: Certificate }
   - { package: github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1, resourceName: Issuer }

--- a/internal/controller/cacheserver/controller.go
+++ b/internal/controller/cacheserver/controller.go
@@ -31,6 +31,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
 	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
 	"github.com/kcp-dev/kcp-operator/internal/resources/cacheserver"
@@ -57,6 +58,7 @@ func (r *CacheServerReconciler) SetupWithManager(mgr ctrlruntime.Manager) error 
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=cacheservers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=cacheservers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=cacheservers/finalizers,verbs=update
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledcacheservers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=cert-manager.io,resources=issuers,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch
@@ -87,11 +89,14 @@ func (r *CacheServerReconciler) reconcile(ctx context.Context, server *operatorv
 	ownerRefWrapper := k8creconciling.OwnerRefWrapper(*metav1.NewControllerRef(server, operatorv1alpha1.SchemeGroupVersion.WithKind("CacheServer")))
 	revisionLabels := modifier.RelatedRevisionsLabels(ctx, r.Client)
 
-	if err := reconciling.ReconcileCertificates(ctx, []reconciling.NamedCertificateReconcilerFactory{
+	certReconcilers := []reconciling.NamedCertificateReconcilerFactory{
 		cacheserver.RootCACertificateReconciler(server),
 		cacheserver.ServerCertificateReconciler(server),
 		cacheserver.ClientCertificateReconciler(server),
-	}, server.Namespace, r.Client, ownerRefWrapper); err != nil {
+	}
+
+	var certs []*certmanagerv1.Certificate
+	if err := reconciling.ReconcileCertificates(ctx, certReconcilers, server.Namespace, r.Client, ownerRefWrapper, modifier.Capture(&certs)); err != nil {
 		return err
 	}
 
@@ -103,6 +108,17 @@ func (r *CacheServerReconciler) reconcile(ctx context.Context, server *operatorv
 
 	if err := k8creconciling.ReconcileSecrets(ctx, []k8creconciling.NamedSecretReconcilerFactory{
 		cacheserver.KubeconfigReconciler(server),
+	}, server.Namespace, r.Client, ownerRefWrapper); err != nil {
+		return err
+	}
+
+	revisions, ready := util.CertificateRevisions(certs)
+	if !ready {
+		return nil
+	}
+
+	if err := reconciling.ReconcileCompiledCacheServers(ctx, []reconciling.NamedCompiledCacheServerReconcilerFactory{
+		cacheserver.CompiledCacheServerReconciler(server, util.MutateKeys(revisions, "cert-", "-revision")),
 	}, server.Namespace, r.Client, ownerRefWrapper); err != nil {
 		return err
 	}

--- a/internal/controller/cacheserver/controller_test.go
+++ b/internal/controller/cacheserver/controller_test.go
@@ -18,16 +18,21 @@ package cacheserver
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/stretchr/testify/require"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -80,6 +85,32 @@ func TestReconciling(t *testing.T) {
 				NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(testcase.cacheServer),
 			})
 			require.NoError(t, err)
+
+			compiled := &deployv1alpha1.CompiledCacheServer{}
+			err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(testcase.cacheServer), compiled)
+			require.True(t, apierrors.IsNotFound(err))
+
+			require.NoError(t, util.MarkCertificatesReady(ctx, client, namespace))
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(testcase.cacheServer),
+			})
+			require.NoError(t, err)
+
+			err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(testcase.cacheServer), compiled)
+			require.NoError(t, err)
+			require.Equal(t, testcase.cacheServer.Spec, compiled.Spec.CacheServer)
+			require.Equal(t, testcase.cacheServer.Name, compiled.Labels[resources.CacheServerLabel])
+			require.Len(t, compiled.OwnerReferences, 1)
+			require.Equal(t, "CacheServer", compiled.OwnerReferences[0].Kind)
+			require.Equal(t, testcase.cacheServer.Name, compiled.OwnerReferences[0].Name)
+
+			certs := &certmanagerv1.CertificateList{}
+			require.NoError(t, client.List(ctx, certs, ctrlruntimeclient.InNamespace(namespace)))
+			require.NotEmpty(t, certs.Items)
+			for _, cert := range certs.Items {
+				require.Equal(t, "1", compiled.Annotations[fmt.Sprintf("operator.kcp.io/cert-%s-revision", cert.Name)])
+			}
 		})
 	}
 }

--- a/internal/controller/frontproxy/controller.go
+++ b/internal/controller/frontproxy/controller.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	k8creconciling "k8c.io/reconciler/pkg/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -41,6 +42,7 @@ import (
 	bundlehelper "github.com/kcp-dev/kcp-operator/internal/controller/bundle"
 	"github.com/kcp-dev/kcp-operator/internal/controller/util"
 	"github.com/kcp-dev/kcp-operator/internal/metrics"
+	"github.com/kcp-dev/kcp-operator/internal/reconciling"
 	"github.com/kcp-dev/kcp-operator/internal/resources"
 	"github.com/kcp-dev/kcp-operator/internal/resources/frontproxy"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
@@ -88,6 +90,7 @@ func (r *FrontProxyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=frontproxies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=frontproxies/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=frontproxies/finalizers,verbs=update
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledfrontproxies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services;configmaps;secrets,verbs=get;list;watch;create;update;patch;delete
@@ -145,6 +148,14 @@ func (r *FrontProxyReconciler) reconcile(ctx context.Context, frontProxy *operat
 	}
 
 	fpReconciler := frontproxy.NewFrontProxy(frontProxy, rootShard)
+
+	ownerRefWrapper := k8creconciling.OwnerRefWrapper(*metav1.NewControllerRef(frontProxy, operatorv1alpha1.SchemeGroupVersion.WithKind("FrontProxy")))
+
+	if err := reconciling.ReconcileCompiledFrontProxys(ctx, []reconciling.NamedCompiledFrontProxyReconcilerFactory{
+		frontproxy.CompiledFrontProxyReconciler(frontProxy, rootShard, nil),
+	}, frontProxy.Namespace, r.Client, ownerRefWrapper); err != nil {
+		errs = append(errs, err)
+	}
 
 	// Deployment will be scaled to 0 if bundle annotation is present
 	if err := fpReconciler.Reconcile(ctx, r.Client, frontProxy.Namespace); err != nil {

--- a/internal/controller/frontproxy/controller_test.go
+++ b/internal/controller/frontproxy/controller_test.go
@@ -29,6 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -146,6 +148,18 @@ func TestReconciling(t *testing.T) {
 				NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(testcase.frontProxy),
 			})
 			require.NoError(t, err)
+
+			compiled := &deployv1alpha1.CompiledFrontProxy{}
+			err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(testcase.frontProxy), compiled)
+			require.NoError(t, err)
+			require.Equal(t, testcase.frontProxy.Spec, compiled.Spec.FrontProxy)
+			require.Equal(t, testcase.rootShard.Name, compiled.Spec.RootShard.Name)
+			require.Equal(t, testcase.rootShard.Spec, compiled.Spec.RootShard.Spec)
+			require.Equal(t, testcase.rootShard.Name, compiled.Labels[resources.RootShardLabel])
+			require.Equal(t, testcase.frontProxy.Name, compiled.Labels[resources.FrontProxyLabel])
+			require.Len(t, compiled.OwnerReferences, 1)
+			require.Equal(t, "FrontProxy", compiled.OwnerReferences[0].Kind)
+			require.Equal(t, testcase.frontProxy.Name, compiled.OwnerReferences[0].Name)
 		})
 	}
 }

--- a/internal/controller/rootshard/controller.go
+++ b/internal/controller/rootshard/controller.go
@@ -111,6 +111,7 @@ func (r *RootShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=virtualworkspaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=rootshards/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=rootshards/finalizers,verbs=update
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledrootshards,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=issuers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
@@ -252,6 +253,12 @@ func (r *RootShardReconciler) reconcile(ctx context.Context, rootShard *operator
 
 	// Deployment will be scaled to 0 if bundle annotation is present
 	if vwConfigValid {
+		if err := reconciling.ReconcileCompiledRootShards(ctx, []reconciling.NamedCompiledRootShardReconcilerFactory{
+			rootshard.CompiledRootShardReconciler(rootShard, kcpVW, nil),
+		}, rootShard.Namespace, r.Client, ownerRefWrapper); err != nil {
+			errs = append(errs, err)
+		}
+
 		if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{
 			rootshard.DeploymentReconciler(rootShard, kcpVW),
 		}, rootShard.Namespace, r.Client, ownerRefWrapper, revisionLabels); err != nil {

--- a/internal/controller/rootshard/controller_test.go
+++ b/internal/controller/rootshard/controller_test.go
@@ -29,6 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -119,6 +121,16 @@ func TestReconciling(t *testing.T) {
 				NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(testcase.rootShard),
 			})
 			require.NoError(t, err)
+
+			compiled := &deployv1alpha1.CompiledRootShard{}
+			err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(testcase.rootShard), compiled)
+			require.NoError(t, err)
+			require.Equal(t, testcase.rootShard.Spec, compiled.Spec.RootShard)
+			require.Nil(t, compiled.Spec.VirtualWorkspace)
+			require.Equal(t, testcase.rootShard.Name, compiled.Labels[resources.RootShardLabel])
+			require.Len(t, compiled.OwnerReferences, 1)
+			require.Equal(t, "RootShard", compiled.OwnerReferences[0].Kind)
+			require.Equal(t, testcase.rootShard.Name, compiled.OwnerReferences[0].Name)
 		})
 	}
 }

--- a/internal/controller/shard/controller.go
+++ b/internal/controller/shard/controller.go
@@ -119,6 +119,7 @@ func (r *ShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=shards,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=shards/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=shards/finalizers,verbs=update
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledshards,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=secrets;services,verbs=get;list;watch;create;update;patch;delete
@@ -194,7 +195,8 @@ func (r *ShardReconciler) reconcile(ctx context.Context, s *operatorv1alpha1.Sha
 		shard.ExternalLogicalClusterAdminCertificateReconciler(s, rootShard),
 	}
 
-	if err := reconciling.ReconcileCertificates(ctx, certReconcilers, s.Namespace, r.Client, ownerRefWrapper); err != nil {
+	var certs []*certmanagerv1.Certificate
+	if err := reconciling.ReconcileCertificates(ctx, certReconcilers, s.Namespace, r.Client, ownerRefWrapper, modifier.Capture(&certs)); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -237,8 +239,16 @@ func (r *ShardReconciler) reconcile(ctx context.Context, s *operatorv1alpha1.Sha
 		}
 	}
 
+	revisions, ready := util.CertificateRevisions(certs)
+
 	// Deployment will be scaled to 0 if bundle annotation is present
-	if vwConfigValid {
+	if vwConfigValid && ready {
+		if err := reconciling.ReconcileCompiledShards(ctx, []reconciling.NamedCompiledShardReconcilerFactory{
+			shard.CompiledShardReconciler(s, rootShard, kcpVW, util.MutateKeys(revisions, "cert-", "-revision")),
+		}, s.Namespace, r.Client, ownerRefWrapper); err != nil {
+			errs = append(errs, err)
+		}
+
 		if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{
 			shard.DeploymentReconciler(s, rootShard, kcpVW),
 		}, s.Namespace, r.Client, ownerRefWrapper, revisionLabels); err != nil {

--- a/internal/controller/shard/controller_test.go
+++ b/internal/controller/shard/controller_test.go
@@ -18,6 +18,7 @@ package shard
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -25,6 +26,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
@@ -33,6 +35,9 @@ import (
 	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -246,6 +251,7 @@ func TestReconciling(t *testing.T) {
 	require.Nil(t, corev1.AddToScheme(scheme))
 	require.Nil(t, appsv1.AddToScheme(scheme))
 	require.Nil(t, operatorv1alpha1.AddToScheme(scheme))
+	require.Nil(t, deployv1alpha1.AddToScheme(scheme))
 	require.Nil(t, certmanagerv1.AddToScheme(scheme))
 
 	for _, testcase := range testcases {
@@ -280,6 +286,36 @@ func TestReconciling(t *testing.T) {
 				NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(testcase.shard),
 			})
 			require.NoError(t, err)
+
+			compiled := &deployv1alpha1.CompiledShard{}
+			err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(testcase.shard), compiled)
+			require.True(t, apierrors.IsNotFound(err))
+
+			require.NoError(t, util.MarkCertificatesReady(ctx, client, namespace))
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(testcase.shard),
+			})
+			require.NoError(t, err)
+
+			err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(testcase.shard), compiled)
+			require.NoError(t, err)
+			require.Equal(t, testcase.shard.Spec, compiled.Spec.Shard)
+			require.Equal(t, testcase.rootShard.Name, compiled.Spec.RootShard.Name)
+			require.Equal(t, testcase.rootShard.Spec, compiled.Spec.RootShard.Spec)
+			require.Nil(t, compiled.Spec.VirtualWorkspace)
+			require.Equal(t, testcase.rootShard.Name, compiled.Labels[resources.RootShardLabel])
+			require.Equal(t, testcase.shard.Name, compiled.Labels[resources.ShardLabel])
+			require.Len(t, compiled.OwnerReferences, 1)
+			require.Equal(t, "Shard", compiled.OwnerReferences[0].Kind)
+			require.Equal(t, testcase.shard.Name, compiled.OwnerReferences[0].Name)
+
+			certs := &certmanagerv1.CertificateList{}
+			require.NoError(t, client.List(ctx, certs, ctrlruntimeclient.InNamespace(namespace)))
+			require.NotEmpty(t, certs.Items)
+			for _, cert := range certs.Items {
+				require.Equal(t, "1", compiled.Annotations[fmt.Sprintf("operator.kcp.io/cert-%s-revision", cert.Name)])
+			}
 
 			if testcase.checkFunc != nil {
 				testcase.checkFunc(t, client, testcase.shard)
@@ -518,6 +554,7 @@ func TestClientCABundleMerging(t *testing.T) {
 	require.Nil(t, corev1.AddToScheme(scheme))
 	require.Nil(t, appsv1.AddToScheme(scheme))
 	require.Nil(t, operatorv1alpha1.AddToScheme(scheme))
+	require.Nil(t, deployv1alpha1.AddToScheme(scheme))
 	require.Nil(t, certmanagerv1.AddToScheme(scheme))
 
 	for _, tc := range testcases {

--- a/internal/controller/util/test.go
+++ b/internal/controller/util/test.go
@@ -17,14 +17,20 @@ limitations under the License.
 package util
 
 import (
+	"context"
+
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -33,8 +39,31 @@ func GetTestScheme() *runtime.Scheme {
 	utilruntime.Must(metav1.AddMetaToScheme(scheme))
 	utilruntime.Must(corev1.AddToScheme(scheme))
 	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(deployv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(certmanagerv1.AddToScheme(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
 
 	return scheme
+}
+
+// MarkCertificatesReady sets all Ready=true certificates in the given namespace.
+func MarkCertificatesReady(ctx context.Context, client ctrlruntimeclient.Client, namespace string) error {
+	certs := &certmanagerv1.CertificateList{}
+	if err := client.List(ctx, certs, ctrlruntimeclient.InNamespace(namespace)); err != nil {
+		return err
+	}
+
+	for i := range certs.Items {
+		cert := &certs.Items[i]
+		cert.Status.Revision = ptr.To(1)
+		cert.Status.Conditions = []certmanagerv1.CertificateCondition{{
+			Type:   certmanagerv1.CertificateConditionReady,
+			Status: certmanagermetav1.ConditionTrue,
+		}}
+		if err := client.Update(ctx, cert); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/internal/controller/util/util.go
+++ b/internal/controller/util/util.go
@@ -19,6 +19,10 @@ package util
 import (
 	"context"
 	"fmt"
+	"strconv"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -34,6 +38,40 @@ import (
 
 func deploymentReady(dep appsv1.Deployment) bool {
 	return dep.Status.UpdatedReplicas == dep.Status.ReadyReplicas && dep.Status.ReadyReplicas == ptr.Deref(dep.Spec.Replicas, 0)
+}
+
+// CertificateRevisions returns a map of name to revision for each certificate.
+// It returns false if any Certificate is not ready.
+func CertificateRevisions(certs []*certmanagerv1.Certificate) (map[string]string, bool) {
+	revisions := make(map[string]string, len(certs))
+
+	for _, cert := range certs {
+		if !certificateReady(cert) {
+			return nil, false
+		}
+
+		revisions[cert.Name] = strconv.Itoa(ptr.Deref(cert.Status.Revision, 0))
+	}
+
+	return revisions, true
+}
+
+func certificateReady(cert *certmanagerv1.Certificate) bool {
+	for _, cond := range cert.Status.Conditions {
+		if cond.Type == certmanagerv1.CertificateConditionReady {
+			return cond.Status == certmanagermetav1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// MutateKeys returns a copy of m with each key wrapped by prefix and suffix.
+func MutateKeys(m map[string]string, prefix, suffix string) map[string]string {
+	result := make(map[string]string, len(m))
+	for k, v := range m {
+		result[prefix+k+suffix] = v
+	}
+	return result
 }
 
 func GetDeploymentAvailableCondition(ctx context.Context, client ctrlruntimeclient.Client, key types.NamespacedName) (metav1.Condition, error) {

--- a/internal/controller/util/util_test.go
+++ b/internal/controller/util/util_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func readyCertificate(name string, revision int) *certmanagerv1.Certificate {
+	return &certmanagerv1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: certmanagerv1.CertificateStatus{
+			Revision: ptr.To(revision),
+			Conditions: []certmanagerv1.CertificateCondition{{
+				Type:   certmanagerv1.CertificateConditionReady,
+				Status: certmanagermetav1.ConditionTrue,
+			}},
+		},
+	}
+}
+
+func TestCertificateRevisions(t *testing.T) {
+	revisions, ready := CertificateRevisions([]*certmanagerv1.Certificate{
+		readyCertificate("ca", 1),
+		readyCertificate("server", 4),
+	})
+
+	if !ready {
+		t.Fatal("expected certificates to be ready")
+	}
+
+	expected := map[string]string{
+		"ca":     "1",
+		"server": "4",
+	}
+	if len(revisions) != len(expected) {
+		t.Fatalf("expected %d revisions, got %d", len(expected), len(revisions))
+	}
+	for k, v := range expected {
+		if revisions[k] != v {
+			t.Errorf("expected %s=%q, got %q", k, v, revisions[k])
+		}
+	}
+}
+
+func TestCertificateRevisionsNotReady(t *testing.T) {
+	notReady := &certmanagerv1.Certificate{ObjectMeta: metav1.ObjectMeta{Name: "pending"}}
+
+	if _, ready := CertificateRevisions([]*certmanagerv1.Certificate{readyCertificate("ca", 1), notReady}); ready {
+		t.Error("expected ready=false with a pending certificate")
+	}
+
+	// Objects captured on the create path are empty and must not count as ready.
+	if _, ready := CertificateRevisions([]*certmanagerv1.Certificate{{}}); ready {
+		t.Error("expected ready=false with an empty certificate")
+	}
+}

--- a/internal/controller/virtualworkspace/controller.go
+++ b/internal/controller/virtualworkspace/controller.go
@@ -70,6 +70,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=virtualworkspaces,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=virtualworkspaces/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledvirtualworkspaces,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=shards,verbs=get;list;watch
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=rootshards,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
@@ -197,10 +198,11 @@ func (r *Reconciler) reconcile(ctx context.Context, vw *operatorv1alpha1.Virtual
 	ownerRefWrapper := k8creconciling.OwnerRefWrapper(*metav1.NewControllerRef(vw, operatorv1alpha1.SchemeGroupVersion.WithKind("VirtualWorkspace")))
 	revisionLabels := modifier.RelatedRevisionsLabels(ctx, r.Client)
 
+	var certs []*certmanagerv1.Certificate
 	if err := reconciling.ReconcileCertificates(ctx, []reconciling.NamedCertificateReconcilerFactory{
 		virtualworkspace.ClientCertificateReconciler(vw, rootShard),
 		virtualworkspace.ServerCertificateReconciler(vw, rootShard),
-	}, vw.Namespace, r.Client, ownerRefWrapper); err != nil {
+	}, vw.Namespace, r.Client, ownerRefWrapper, modifier.Capture(&certs)); err != nil {
 		return conditions, err
 	}
 
@@ -210,6 +212,17 @@ func (r *Reconciler) reconcile(ctx context.Context, vw *operatorv1alpha1.Virtual
 		}, vw.Namespace, r.Client, ownerRefWrapper); err != nil {
 			return conditions, err
 		}
+	}
+
+	revisions, ready := util.CertificateRevisions(certs)
+	if !ready {
+		return conditions, nil
+	}
+
+	if err := reconciling.ReconcileCompiledVirtualWorkspaces(ctx, []reconciling.NamedCompiledVirtualWorkspaceReconcilerFactory{
+		virtualworkspace.CompiledVirtualWorkspaceReconciler(vw, rootShard, shard, util.MutateKeys(revisions, "cert-", "-revision")),
+	}, vw.Namespace, r.Client, ownerRefWrapper); err != nil {
+		return conditions, err
 	}
 
 	if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{

--- a/internal/controller/virtualworkspace/controller_test.go
+++ b/internal/controller/virtualworkspace/controller_test.go
@@ -18,17 +18,22 @@ package virtualworkspace
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -102,6 +107,36 @@ func TestReconciling(t *testing.T) {
 				NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(testcase.virtualWorkspace),
 			})
 			require.NoError(t, err)
+
+			compiled := &deployv1alpha1.CompiledVirtualWorkspace{}
+			err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(testcase.virtualWorkspace), compiled)
+			require.True(t, apierrors.IsNotFound(err))
+
+			require.NoError(t, util.MarkCertificatesReady(ctx, client, namespace))
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(testcase.virtualWorkspace),
+			})
+			require.NoError(t, err)
+
+			err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(testcase.virtualWorkspace), compiled)
+			require.NoError(t, err)
+			require.Equal(t, testcase.virtualWorkspace.Spec, compiled.Spec.VirtualWorkspace)
+			require.Equal(t, testcase.rootShard.Name, compiled.Spec.RootShard.Name)
+			require.Equal(t, testcase.rootShard.Spec, compiled.Spec.RootShard.Spec)
+			require.Nil(t, compiled.Spec.Shard)
+			require.Equal(t, testcase.rootShard.Name, compiled.Labels[resources.RootShardLabel])
+			require.Equal(t, testcase.virtualWorkspace.Name, compiled.Labels[resources.VirtualWorkspaceLabel])
+			require.Len(t, compiled.OwnerReferences, 1)
+			require.Equal(t, "VirtualWorkspace", compiled.OwnerReferences[0].Kind)
+			require.Equal(t, testcase.virtualWorkspace.Name, compiled.OwnerReferences[0].Name)
+
+			certs := &certmanagerv1.CertificateList{}
+			require.NoError(t, client.List(ctx, certs, ctrlruntimeclient.InNamespace(namespace)))
+			require.NotEmpty(t, certs.Items)
+			for _, cert := range certs.Items {
+				require.Equal(t, "1", compiled.Annotations[fmt.Sprintf("operator.kcp.io/cert-%s-revision", cert.Name)])
+			}
 		})
 	}
 }

--- a/internal/reconciling/modifier/capture.go
+++ b/internal/reconciling/modifier/capture.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2026 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modifier
+
+import (
+	"k8c.io/reconciler/pkg/reconciling"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Capture appends the object of every ensured object through the reconciler chain to out.
+// Objects that don't exist yet are empty objects.
+func Capture[T ctrlruntimeclient.Object](out *[]T) reconciling.ObjectModifier {
+	return func(reconciler reconciling.ObjectReconciler) reconciling.ObjectReconciler {
+		return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+			obj, err := reconciler(existing)
+			if err != nil {
+				return obj, err
+			}
+
+			if captured, ok := existing.(T); ok {
+				*out = append(*out, captured)
+			}
+
+			return obj, nil
+		}
+	}
+}

--- a/internal/reconciling/modifier/capture_test.go
+++ b/internal/reconciling/modifier/capture_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modifier
+
+import (
+	"fmt"
+	"testing"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestCapture(t *testing.T) {
+	reconciler := func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		return existing, nil
+	}
+
+	existing := &certmanagerv1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "cert"},
+		Status:     certmanagerv1.CertificateStatus{Revision: ptr.To(3)},
+	}
+
+	var certs []*certmanagerv1.Certificate
+	if _, err := Capture(&certs)(reconciler)(existing); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(certs) != 1 {
+		t.Fatalf("expected 1 captured object, got %d", len(certs))
+	}
+	if certs[0].Name != "cert" || ptr.Deref(certs[0].Status.Revision, 0) != 3 {
+		t.Errorf("captured object does not match cluster state: %+v", certs[0])
+	}
+}
+
+func TestCaptureSkipsOtherTypes(t *testing.T) {
+	reconciler := func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		return existing, nil
+	}
+
+	var certs []*certmanagerv1.Certificate
+	if _, err := Capture(&certs)(reconciler)(&corev1.Secret{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(certs) != 0 {
+		t.Errorf("expected no captured objects, got %d", len(certs))
+	}
+}
+
+func TestCaptureSkipsOnError(t *testing.T) {
+	reconciler := func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		return nil, fmt.Errorf("boom")
+	}
+
+	var certs []*certmanagerv1.Certificate
+	if _, err := Capture(&certs)(reconciler)(&certmanagerv1.Certificate{}); err == nil {
+		t.Fatal("expected error")
+	}
+
+	if len(certs) != 0 {
+		t.Errorf("expected no captured objects, got %d", len(certs))
+	}
+}

--- a/internal/reconciling/zz_generated_reconcile.go
+++ b/internal/reconciling/zz_generated_reconcile.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -208,6 +209,191 @@ func ReconcileKubeconfigs(ctx context.Context, namedFactories []NamedKubeconfigR
 
 		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &operatorv1alpha1.Kubeconfig{}, false); err != nil {
 			return fmt.Errorf("failed to ensure Kubeconfig %s/%s: %w", namespace, name, err)
+		}
+	}
+
+	return nil
+}
+
+// CompiledRootShardReconciler defines an interface to create/update CompiledRootShards.
+type CompiledRootShardReconciler = func(existing *deployv1alpha1.CompiledRootShard) (*deployv1alpha1.CompiledRootShard, error)
+
+// NamedCompiledRootShardReconcilerFactory returns the name of the resource and the corresponding Reconciler function.
+type NamedCompiledRootShardReconcilerFactory = func() (name string, reconciler CompiledRootShardReconciler)
+
+// CompiledRootShardObjectWrapper adds a wrapper so the CompiledRootShardReconciler matches ObjectReconciler.
+// This is needed as Go does not support function interface matching.
+func CompiledRootShardObjectWrapper(reconciler CompiledRootShardReconciler) reconciling.ObjectReconciler {
+	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		if existing != nil {
+			return reconciler(existing.(*deployv1alpha1.CompiledRootShard))
+		}
+		return reconciler(&deployv1alpha1.CompiledRootShard{})
+	}
+}
+
+// ReconcileCompiledRootShards will create and update the CompiledRootShards coming from the passed CompiledRootShardReconciler slice.
+func ReconcileCompiledRootShards(ctx context.Context, namedFactories []NamedCompiledRootShardReconcilerFactory, namespace string, client ctrlruntimeclient.Client, objectModifiers ...reconciling.ObjectModifier) error {
+	for _, factory := range namedFactories {
+		name, reconciler := factory()
+		reconcileObject := CompiledRootShardObjectWrapper(reconciler)
+		reconcileObject = reconciling.CreateWithNamespace(reconcileObject, namespace)
+		reconcileObject = reconciling.CreateWithName(reconcileObject, name)
+
+		for _, objectModifier := range objectModifiers {
+			reconcileObject = objectModifier(reconcileObject)
+		}
+
+		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &deployv1alpha1.CompiledRootShard{}, false); err != nil {
+			return fmt.Errorf("failed to ensure CompiledRootShard %s/%s: %w", namespace, name, err)
+		}
+	}
+
+	return nil
+}
+
+// CompiledShardReconciler defines an interface to create/update CompiledShards.
+type CompiledShardReconciler = func(existing *deployv1alpha1.CompiledShard) (*deployv1alpha1.CompiledShard, error)
+
+// NamedCompiledShardReconcilerFactory returns the name of the resource and the corresponding Reconciler function.
+type NamedCompiledShardReconcilerFactory = func() (name string, reconciler CompiledShardReconciler)
+
+// CompiledShardObjectWrapper adds a wrapper so the CompiledShardReconciler matches ObjectReconciler.
+// This is needed as Go does not support function interface matching.
+func CompiledShardObjectWrapper(reconciler CompiledShardReconciler) reconciling.ObjectReconciler {
+	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		if existing != nil {
+			return reconciler(existing.(*deployv1alpha1.CompiledShard))
+		}
+		return reconciler(&deployv1alpha1.CompiledShard{})
+	}
+}
+
+// ReconcileCompiledShards will create and update the CompiledShards coming from the passed CompiledShardReconciler slice.
+func ReconcileCompiledShards(ctx context.Context, namedFactories []NamedCompiledShardReconcilerFactory, namespace string, client ctrlruntimeclient.Client, objectModifiers ...reconciling.ObjectModifier) error {
+	for _, factory := range namedFactories {
+		name, reconciler := factory()
+		reconcileObject := CompiledShardObjectWrapper(reconciler)
+		reconcileObject = reconciling.CreateWithNamespace(reconcileObject, namespace)
+		reconcileObject = reconciling.CreateWithName(reconcileObject, name)
+
+		for _, objectModifier := range objectModifiers {
+			reconcileObject = objectModifier(reconcileObject)
+		}
+
+		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &deployv1alpha1.CompiledShard{}, false); err != nil {
+			return fmt.Errorf("failed to ensure CompiledShard %s/%s: %w", namespace, name, err)
+		}
+	}
+
+	return nil
+}
+
+// CompiledCacheServerReconciler defines an interface to create/update CompiledCacheServers.
+type CompiledCacheServerReconciler = func(existing *deployv1alpha1.CompiledCacheServer) (*deployv1alpha1.CompiledCacheServer, error)
+
+// NamedCompiledCacheServerReconcilerFactory returns the name of the resource and the corresponding Reconciler function.
+type NamedCompiledCacheServerReconcilerFactory = func() (name string, reconciler CompiledCacheServerReconciler)
+
+// CompiledCacheServerObjectWrapper adds a wrapper so the CompiledCacheServerReconciler matches ObjectReconciler.
+// This is needed as Go does not support function interface matching.
+func CompiledCacheServerObjectWrapper(reconciler CompiledCacheServerReconciler) reconciling.ObjectReconciler {
+	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		if existing != nil {
+			return reconciler(existing.(*deployv1alpha1.CompiledCacheServer))
+		}
+		return reconciler(&deployv1alpha1.CompiledCacheServer{})
+	}
+}
+
+// ReconcileCompiledCacheServers will create and update the CompiledCacheServers coming from the passed CompiledCacheServerReconciler slice.
+func ReconcileCompiledCacheServers(ctx context.Context, namedFactories []NamedCompiledCacheServerReconcilerFactory, namespace string, client ctrlruntimeclient.Client, objectModifiers ...reconciling.ObjectModifier) error {
+	for _, factory := range namedFactories {
+		name, reconciler := factory()
+		reconcileObject := CompiledCacheServerObjectWrapper(reconciler)
+		reconcileObject = reconciling.CreateWithNamespace(reconcileObject, namespace)
+		reconcileObject = reconciling.CreateWithName(reconcileObject, name)
+
+		for _, objectModifier := range objectModifiers {
+			reconcileObject = objectModifier(reconcileObject)
+		}
+
+		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &deployv1alpha1.CompiledCacheServer{}, false); err != nil {
+			return fmt.Errorf("failed to ensure CompiledCacheServer %s/%s: %w", namespace, name, err)
+		}
+	}
+
+	return nil
+}
+
+// CompiledFrontProxyReconciler defines an interface to create/update CompiledFrontProxys.
+type CompiledFrontProxyReconciler = func(existing *deployv1alpha1.CompiledFrontProxy) (*deployv1alpha1.CompiledFrontProxy, error)
+
+// NamedCompiledFrontProxyReconcilerFactory returns the name of the resource and the corresponding Reconciler function.
+type NamedCompiledFrontProxyReconcilerFactory = func() (name string, reconciler CompiledFrontProxyReconciler)
+
+// CompiledFrontProxyObjectWrapper adds a wrapper so the CompiledFrontProxyReconciler matches ObjectReconciler.
+// This is needed as Go does not support function interface matching.
+func CompiledFrontProxyObjectWrapper(reconciler CompiledFrontProxyReconciler) reconciling.ObjectReconciler {
+	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		if existing != nil {
+			return reconciler(existing.(*deployv1alpha1.CompiledFrontProxy))
+		}
+		return reconciler(&deployv1alpha1.CompiledFrontProxy{})
+	}
+}
+
+// ReconcileCompiledFrontProxys will create and update the CompiledFrontProxys coming from the passed CompiledFrontProxyReconciler slice.
+func ReconcileCompiledFrontProxys(ctx context.Context, namedFactories []NamedCompiledFrontProxyReconcilerFactory, namespace string, client ctrlruntimeclient.Client, objectModifiers ...reconciling.ObjectModifier) error {
+	for _, factory := range namedFactories {
+		name, reconciler := factory()
+		reconcileObject := CompiledFrontProxyObjectWrapper(reconciler)
+		reconcileObject = reconciling.CreateWithNamespace(reconcileObject, namespace)
+		reconcileObject = reconciling.CreateWithName(reconcileObject, name)
+
+		for _, objectModifier := range objectModifiers {
+			reconcileObject = objectModifier(reconcileObject)
+		}
+
+		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &deployv1alpha1.CompiledFrontProxy{}, false); err != nil {
+			return fmt.Errorf("failed to ensure CompiledFrontProxy %s/%s: %w", namespace, name, err)
+		}
+	}
+
+	return nil
+}
+
+// CompiledVirtualWorkspaceReconciler defines an interface to create/update CompiledVirtualWorkspaces.
+type CompiledVirtualWorkspaceReconciler = func(existing *deployv1alpha1.CompiledVirtualWorkspace) (*deployv1alpha1.CompiledVirtualWorkspace, error)
+
+// NamedCompiledVirtualWorkspaceReconcilerFactory returns the name of the resource and the corresponding Reconciler function.
+type NamedCompiledVirtualWorkspaceReconcilerFactory = func() (name string, reconciler CompiledVirtualWorkspaceReconciler)
+
+// CompiledVirtualWorkspaceObjectWrapper adds a wrapper so the CompiledVirtualWorkspaceReconciler matches ObjectReconciler.
+// This is needed as Go does not support function interface matching.
+func CompiledVirtualWorkspaceObjectWrapper(reconciler CompiledVirtualWorkspaceReconciler) reconciling.ObjectReconciler {
+	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		if existing != nil {
+			return reconciler(existing.(*deployv1alpha1.CompiledVirtualWorkspace))
+		}
+		return reconciler(&deployv1alpha1.CompiledVirtualWorkspace{})
+	}
+}
+
+// ReconcileCompiledVirtualWorkspaces will create and update the CompiledVirtualWorkspaces coming from the passed CompiledVirtualWorkspaceReconciler slice.
+func ReconcileCompiledVirtualWorkspaces(ctx context.Context, namedFactories []NamedCompiledVirtualWorkspaceReconcilerFactory, namespace string, client ctrlruntimeclient.Client, objectModifiers ...reconciling.ObjectModifier) error {
+	for _, factory := range namedFactories {
+		name, reconciler := factory()
+		reconcileObject := CompiledVirtualWorkspaceObjectWrapper(reconciler)
+		reconcileObject = reconciling.CreateWithNamespace(reconcileObject, namespace)
+		reconcileObject = reconciling.CreateWithName(reconcileObject, name)
+
+		for _, objectModifier := range objectModifiers {
+			reconcileObject = objectModifier(reconcileObject)
+		}
+
+		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &deployv1alpha1.CompiledVirtualWorkspace{}, false); err != nil {
+			return fmt.Errorf("failed to ensure CompiledVirtualWorkspace %s/%s: %w", namespace, name, err)
 		}
 	}
 

--- a/internal/resources/cacheserver/compiled.go
+++ b/internal/resources/cacheserver/compiled.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cacheserver
+
+import (
+	"maps"
+
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/reconciling"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+// CompiledCacheServerReconciler compiles the given CacheServer into a CompiledCacheServer.
+func CompiledCacheServerReconciler(server *operatorv1alpha1.CacheServer, revisions map[string]string) reconciling.NamedCompiledCacheServerReconcilerFactory {
+	return func() (string, reconciling.CompiledCacheServerReconciler) {
+		return server.Name, func(compiled *deployv1alpha1.CompiledCacheServer) (*deployv1alpha1.CompiledCacheServer, error) {
+			compiled.Labels = maps.Clone(server.Labels)
+			if compiled.Labels == nil {
+				compiled.Labels = make(map[string]string)
+			}
+			compiled.Labels[resources.CacheServerLabel] = server.Name
+			compiled.Annotations = maps.Clone(server.Annotations)
+			if compiled.Annotations == nil {
+				compiled.Annotations = make(map[string]string)
+			}
+			maps.Copy(compiled.Annotations, util.MutateKeys(revisions, operatorv1alpha1.GroupName+"/", ""))
+
+			compiled.Spec.CacheServer = server.Spec
+
+			return compiled, nil
+		}
+	}
+}

--- a/internal/resources/frontproxy/compiled.go
+++ b/internal/resources/frontproxy/compiled.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frontproxy
+
+import (
+	"maps"
+
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/reconciling"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+// CompiledFrontProxyReconciler compiles the given FrontProxy and its RootShard
+// into a CompiledFrontProxy.
+func CompiledFrontProxyReconciler(frontProxy *operatorv1alpha1.FrontProxy, rootShard *operatorv1alpha1.RootShard, revisions map[string]string) reconciling.NamedCompiledFrontProxyReconcilerFactory {
+	return func() (string, reconciling.CompiledFrontProxyReconciler) {
+		return frontProxy.Name, func(compiled *deployv1alpha1.CompiledFrontProxy) (*deployv1alpha1.CompiledFrontProxy, error) {
+			compiled.Labels = maps.Clone(frontProxy.Labels)
+			if compiled.Labels == nil {
+				compiled.Labels = make(map[string]string)
+			}
+			compiled.Labels[resources.RootShardLabel] = rootShard.Name
+			compiled.Labels[resources.FrontProxyLabel] = frontProxy.Name
+			compiled.Annotations = maps.Clone(frontProxy.Annotations)
+			if compiled.Annotations == nil {
+				compiled.Annotations = make(map[string]string)
+			}
+			maps.Copy(compiled.Annotations, util.MutateKeys(revisions, operatorv1alpha1.GroupName+"/", ""))
+
+			compiled.Spec.FrontProxy = frontProxy.Spec
+			compiled.Spec.RootShard = deployv1alpha1.NamedRootShardSpec{
+				Name: rootShard.Name,
+				Spec: rootShard.Spec,
+			}
+
+			return compiled, nil
+		}
+	}
+}

--- a/internal/resources/rootshard/compiled.go
+++ b/internal/resources/rootshard/compiled.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rootshard
+
+import (
+	"maps"
+
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/reconciling"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+// CompiledRootShardReconciler compiles the given RootShard and its optional kcp
+// virtual workspace into a CompiledRootShard.
+func CompiledRootShardReconciler(rootShard *operatorv1alpha1.RootShard, kcpVW *operatorv1alpha1.VirtualWorkspace, revisions map[string]string) reconciling.NamedCompiledRootShardReconcilerFactory {
+	return func() (string, reconciling.CompiledRootShardReconciler) {
+		return rootShard.Name, func(compiled *deployv1alpha1.CompiledRootShard) (*deployv1alpha1.CompiledRootShard, error) {
+			compiled.Labels = maps.Clone(rootShard.Labels)
+			if compiled.Labels == nil {
+				compiled.Labels = make(map[string]string)
+			}
+			compiled.Labels[resources.RootShardLabel] = rootShard.Name
+			compiled.Annotations = maps.Clone(rootShard.Annotations)
+			if compiled.Annotations == nil {
+				compiled.Annotations = make(map[string]string)
+			}
+			maps.Copy(compiled.Annotations, util.MutateKeys(revisions, operatorv1alpha1.GroupName+"/", ""))
+
+			compiled.Spec.RootShard = rootShard.Spec
+			compiled.Spec.VirtualWorkspace = nil
+			if kcpVW != nil {
+				compiled.Spec.VirtualWorkspace = &deployv1alpha1.NamedVirtualWorkspaceSpec{
+					Name: kcpVW.Name,
+					Spec: kcpVW.Spec,
+				}
+			}
+
+			return compiled, nil
+		}
+	}
+}

--- a/internal/resources/shard/compiled.go
+++ b/internal/resources/shard/compiled.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shard
+
+import (
+	"maps"
+
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/reconciling"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+// CompiledShardReconciler compiles the given Shard, its RootShard and its
+// optional kcp virtual workspace into a CompiledShard.
+func CompiledShardReconciler(shard *operatorv1alpha1.Shard, rootShard *operatorv1alpha1.RootShard, kcpVW *operatorv1alpha1.VirtualWorkspace, revisions map[string]string) reconciling.NamedCompiledShardReconcilerFactory {
+	return func() (string, reconciling.CompiledShardReconciler) {
+		return shard.Name, func(compiled *deployv1alpha1.CompiledShard) (*deployv1alpha1.CompiledShard, error) {
+			compiled.Labels = maps.Clone(shard.Labels)
+			if compiled.Labels == nil {
+				compiled.Labels = make(map[string]string)
+			}
+			compiled.Labels[resources.RootShardLabel] = rootShard.Name
+			compiled.Labels[resources.ShardLabel] = shard.Name
+			compiled.Annotations = maps.Clone(shard.Annotations)
+			if compiled.Annotations == nil {
+				compiled.Annotations = make(map[string]string)
+			}
+			maps.Copy(compiled.Annotations, util.MutateKeys(revisions, operatorv1alpha1.GroupName+"/", ""))
+
+			compiled.Spec.Shard = shard.Spec
+			compiled.Spec.RootShard = deployv1alpha1.NamedRootShardSpec{
+				Name: rootShard.Name,
+				Spec: rootShard.Spec,
+			}
+			compiled.Spec.VirtualWorkspace = nil
+			if kcpVW != nil {
+				compiled.Spec.VirtualWorkspace = &deployv1alpha1.NamedVirtualWorkspaceSpec{
+					Name: kcpVW.Name,
+					Spec: kcpVW.Spec,
+				}
+			}
+
+			return compiled, nil
+		}
+	}
+}

--- a/internal/resources/virtualworkspace/compiled.go
+++ b/internal/resources/virtualworkspace/compiled.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualworkspace
+
+import (
+	"maps"
+
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/reconciling"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+// CompiledVirtualWorkspaceReconciler compiles the given VirtualWorkspace, its
+// RootShard and its optional Shard target into a CompiledVirtualWorkspace.
+func CompiledVirtualWorkspaceReconciler(vw *operatorv1alpha1.VirtualWorkspace, rootShard *operatorv1alpha1.RootShard, shard *operatorv1alpha1.Shard, revisions map[string]string) reconciling.NamedCompiledVirtualWorkspaceReconcilerFactory {
+	return func() (string, reconciling.CompiledVirtualWorkspaceReconciler) {
+		return vw.Name, func(compiled *deployv1alpha1.CompiledVirtualWorkspace) (*deployv1alpha1.CompiledVirtualWorkspace, error) {
+			compiled.Labels = maps.Clone(vw.Labels)
+			if compiled.Labels == nil {
+				compiled.Labels = make(map[string]string)
+			}
+			compiled.Labels[resources.RootShardLabel] = rootShard.Name
+			compiled.Labels[resources.VirtualWorkspaceLabel] = vw.Name
+			compiled.Annotations = maps.Clone(vw.Annotations)
+			if compiled.Annotations == nil {
+				compiled.Annotations = make(map[string]string)
+			}
+			maps.Copy(compiled.Annotations, util.MutateKeys(revisions, operatorv1alpha1.GroupName+"/", ""))
+
+			compiled.Spec.VirtualWorkspace = vw.Spec
+			compiled.Spec.RootShard = deployv1alpha1.NamedRootShardSpec{
+				Name: rootShard.Name,
+				Spec: rootShard.Spec,
+			}
+			compiled.Spec.Shard = nil
+			if shard != nil {
+				compiled.Spec.Shard = &deployv1alpha1.NamedShardSpec{
+					Name: shard.Name,
+					Spec: shard.Spec,
+				}
+			}
+
+			return compiled, nil
+		}
+	}
+}


### PR DESCRIPTION
This PR is part of a stacked PR that splits kcp-operator's functionality
into two controller groups, `config` and `workload` and adds an
intermediate resource group deploy.operator.kcp.io. The config
controller group prepares and compiles resources into resources of the
group deploy.operator.kcp.io.

The `workload` then realizes the compiled resource into workload
resources (`Deployment` and `Service`).

```release-note
NONE
```

/kind feature
