### PR TITLE
Render RootShard workloads from CompiledRootShard

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/kcp-dev/kcp-operator/internal/config"
 	"github.com/kcp-dev/kcp-operator/internal/controller/bundle"
 	"github.com/kcp-dev/kcp-operator/internal/controller/cacheserver"
+	"github.com/kcp-dev/kcp-operator/internal/controller/compiledrootshard"
 	"github.com/kcp-dev/kcp-operator/internal/controller/frontproxy"
 	"github.com/kcp-dev/kcp-operator/internal/controller/kubeconfig"
 	kubeconfigrbac "github.com/kcp-dev/kcp-operator/internal/controller/kubeconfig-rbac"
@@ -209,6 +210,11 @@ func run(ctx context.Context) error {
 			return err
 		}
 	}
+	if controllerGroups.Has(config.ControllerGroupWorkload) {
+		if err := setupWorkloadControllers(mgr, client); err != nil {
+			return err
+		}
+	}
 	// +kubebuilder:scaffold:builder
 
 	metrics.RegisterMetrics()
@@ -277,6 +283,17 @@ func setupConfigControllers(mgr ctrl.Manager, client ctrlruntimeclient.Client) e
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller %s: %w", "KubeconfigRBAC", err)
+	}
+
+	return nil
+}
+
+func setupWorkloadControllers(mgr ctrl.Manager, client ctrlruntimeclient.Client) error {
+	if err := (&compiledrootshard.Reconciler{
+		Client: client,
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "CompiledRootShard", err)
 	}
 
 	return nil

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -60,6 +60,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - deploy.operator.kcp.io
+  resources:
+  - compiledrootshards/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - operator.kcp.io
   resources:
   - bundles

--- a/internal/controller/compiledrootshard/controller.go
+++ b/internal/controller/compiledrootshard/controller.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compiledrootshard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	k8creconciling "k8c.io/reconciler/pkg/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	"github.com/kcp-dev/kcp-operator/internal/resources/frontproxy"
+	"github.com/kcp-dev/kcp-operator/internal/resources/rootshard"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+// requeueAfter is the retry delay when a mounted Secret or ConfigMap does not exist yet.
+const requeueAfter = 10 * time.Second
+
+// Reconciler reconciles a CompiledRootShard object.
+type Reconciler struct {
+	ctrlruntimeclient.Client
+	Scheme *runtime.Scheme
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("compiledrootshard").
+		For(&deployv1alpha1.CompiledRootShard{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.ConfigMap{}).
+		Complete(r)
+}
+
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledrootshards,verbs=get;list;watch
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledrootshards/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=services;configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.V(4).Info("Reconciling")
+
+	var compiled deployv1alpha1.CompiledRootShard
+	if err := r.Get(ctx, req.NamespacedName, &compiled); err != nil {
+		return ctrl.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	if compiled.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	result, recErr := r.reconcile(ctx, &compiled)
+	statusErr := r.reconcileStatus(ctx, &compiled)
+
+	return result, kerrors.NewAggregate([]error{recErr, statusErr})
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, compiled *deployv1alpha1.CompiledRootShard) (ctrl.Result, error) {
+	var (
+		errs    []error
+		requeue bool
+	)
+
+	rootShard := &operatorv1alpha1.RootShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        compiled.Name,
+			Namespace:   compiled.Namespace,
+			Labels:      compiled.Labels,
+			Annotations: compiled.Annotations,
+		},
+		Spec: compiled.Spec.RootShard,
+	}
+
+	var kcpVW *operatorv1alpha1.VirtualWorkspace
+	if compiled.Spec.VirtualWorkspace != nil {
+		kcpVW = &operatorv1alpha1.VirtualWorkspace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      compiled.Spec.VirtualWorkspace.Name,
+				Namespace: compiled.Namespace,
+			},
+			Spec: compiled.Spec.VirtualWorkspace.Spec,
+		}
+	}
+
+	ownerRef := *metav1.NewControllerRef(compiled, deployv1alpha1.SchemeGroupVersion.WithKind("CompiledRootShard"))
+	ownerRefWrapper := k8creconciling.OwnerRefWrapper(ownerRef)
+	revisionLabels := modifier.RelatedRevisionsLabels(ctx, r.Client)
+
+	if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{
+		rootshard.DeploymentReconciler(rootShard, kcpVW),
+	}, compiled.Namespace, r.Client, ownerRefWrapper, revisionLabels); err != nil {
+		if errors.Is(err, modifier.ErrMountNotFound) {
+			requeue = true
+		} else {
+			errs = append(errs, err)
+		}
+	}
+
+	if err := k8creconciling.ReconcileServices(ctx, []k8creconciling.NamedServiceReconcilerFactory{
+		rootshard.ServiceReconciler(rootShard),
+	}, compiled.Namespace, r.Client, ownerRefWrapper); err != nil {
+		errs = append(errs, err)
+	}
+
+	proxyRequeue, err := frontproxy.NewRootShardProxy(rootShard).ReconcileWorkload(ctx, r.Client, compiled.Namespace, ownerRef)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile proxy: %w", err))
+	}
+	requeue = requeue || proxyRequeue
+
+	result := ctrl.Result{}
+	if requeue {
+		result.RequeueAfter = requeueAfter
+	}
+
+	return result, kerrors.NewAggregate(errs)
+}
+
+func (r *Reconciler) reconcileStatus(ctx context.Context, oldCompiled *deployv1alpha1.CompiledRootShard) error {
+	compiled := oldCompiled.DeepCopy()
+
+	rootShard := &operatorv1alpha1.RootShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Name,
+			Namespace: compiled.Namespace,
+		},
+	}
+
+	depKey := types.NamespacedName{Namespace: compiled.Namespace, Name: resources.GetRootShardDeploymentName(rootShard)}
+	cond, err := util.GetDeploymentAvailableCondition(ctx, r.Client, depKey)
+	if err != nil {
+		return err
+	}
+
+	cond.ObservedGeneration = compiled.Generation
+	compiled.Status.Conditions = util.UpdateCondition(compiled.Status.Conditions, cond)
+
+	compiled.Status.Phase = operatorv1alpha1.RootShardPhaseProvisioning
+	if availableCond := apimeta.FindStatusCondition(compiled.Status.Conditions, string(operatorv1alpha1.ConditionTypeAvailable)); availableCond != nil && availableCond.Status == metav1.ConditionTrue {
+		compiled.Status.Phase = operatorv1alpha1.RootShardPhaseRunning
+	}
+
+	if !equality.Semantic.DeepEqual(oldCompiled.Status, compiled.Status) {
+		return r.Status().Patch(ctx, compiled, ctrlruntimeclient.MergeFrom(oldCompiled))
+	}
+
+	return nil
+}

--- a/internal/controller/compiledrootshard/controller_test.go
+++ b/internal/controller/compiledrootshard/controller_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compiledrootshard
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+func TestReconciling(t *testing.T) {
+	const namespace = "compiled-rootshard-tests"
+
+	compiled := &deployv1alpha1.CompiledRootShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rooty",
+			Namespace: namespace,
+		},
+		Spec: deployv1alpha1.CompiledRootShardSpec{
+			RootShard: operatorv1alpha1.RootShardSpec{
+				External: operatorv1alpha1.ExternalConfig{
+					Hostname: "example.kcp.io",
+					Port:     6443,
+				},
+				CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+					Etcd: operatorv1alpha1.EtcdConfig{
+						Endpoints: []string{"https://localhost:2379"},
+					},
+				},
+			},
+		},
+	}
+
+	rootShard := &operatorv1alpha1.RootShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Name,
+			Namespace: compiled.Namespace,
+		},
+	}
+
+	// Secrets mounted into the deployment must exist for the revision-labels modifier.
+	var mountedSecretNames []string
+	for _, ca := range []operatorv1alpha1.CA{
+		operatorv1alpha1.RootCA,
+		operatorv1alpha1.ServerCA,
+		operatorv1alpha1.ServiceAccountCA,
+		operatorv1alpha1.RequestHeaderClientCA,
+		operatorv1alpha1.ClientCA,
+	} {
+		mountedSecretNames = append(mountedSecretNames, resources.GetRootShardCAName(rootShard, ca))
+	}
+	for _, cert := range []operatorv1alpha1.Certificate{
+		operatorv1alpha1.LogicalClusterAdminCertificate,
+		operatorv1alpha1.ExternalLogicalClusterAdminCertificate,
+	} {
+		mountedSecretNames = append(mountedSecretNames, resources.GetRootShardKubeconfigSecret(rootShard, cert))
+	}
+	for _, cert := range []operatorv1alpha1.Certificate{
+		operatorv1alpha1.ServerCertificate,
+		operatorv1alpha1.ServiceAccountCertificate,
+		operatorv1alpha1.ClientCertificate,
+		operatorv1alpha1.LogicalClusterAdminCertificate,
+		operatorv1alpha1.ExternalLogicalClusterAdminCertificate,
+	} {
+		mountedSecretNames = append(mountedSecretNames, resources.GetRootShardCertificateName(rootShard, cert))
+	}
+
+	objects := []ctrlruntimeclient.Object{compiled}
+	for _, name := range mountedSecretNames {
+		objects = append(objects, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		})
+	}
+
+	scheme := util.GetTestScheme()
+
+	client := ctrlruntimefakeclient.
+		NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(compiled).
+		Build()
+
+	ctx := context.Background()
+
+	controllerReconciler := &Reconciler{
+		Client: client,
+		Scheme: client.Scheme(),
+	}
+
+	_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(compiled),
+	})
+	require.NoError(t, err)
+
+	deployment := &appsv1.Deployment{}
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKey{
+		Name:      resources.GetRootShardDeploymentName(rootShard),
+		Namespace: namespace,
+	}, deployment)
+	require.NoError(t, err)
+	require.Len(t, deployment.OwnerReferences, 1)
+	require.Equal(t, "CompiledRootShard", deployment.OwnerReferences[0].Kind)
+	require.Equal(t, compiled.Name, deployment.OwnerReferences[0].Name)
+
+	service := &corev1.Service{}
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKey{
+		Name:      resources.GetRootShardServiceName(rootShard),
+		Namespace: namespace,
+	}, service)
+	require.NoError(t, err)
+	require.Len(t, service.OwnerReferences, 1)
+	require.Equal(t, "CompiledRootShard", service.OwnerReferences[0].Kind)
+	require.Equal(t, compiled.Name, service.OwnerReferences[0].Name)
+
+	updated := &deployv1alpha1.CompiledRootShard{}
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(compiled), updated)
+	require.NoError(t, err)
+	availableCond := apimeta.FindStatusCondition(updated.Status.Conditions, string(operatorv1alpha1.ConditionTypeAvailable))
+	require.NotNil(t, availableCond)
+	require.Equal(t, metav1.ConditionFalse, availableCond.Status)
+	require.Equal(t, operatorv1alpha1.RootShardPhaseProvisioning, updated.Status.Phase)
+}

--- a/internal/controller/rootshard/controller.go
+++ b/internal/controller/rootshard/controller.go
@@ -18,7 +18,6 @@ package rootshard
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -26,7 +25,6 @@ import (
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	k8creconciling "k8c.io/reconciler/pkg/reconciling"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -46,9 +44,9 @@ import (
 	"github.com/kcp-dev/kcp-operator/internal/metrics"
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
 	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
-	"github.com/kcp-dev/kcp-operator/internal/resources"
 	"github.com/kcp-dev/kcp-operator/internal/resources/frontproxy"
 	"github.com/kcp-dev/kcp-operator/internal/resources/rootshard"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -97,9 +95,7 @@ func (r *RootShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("rootshard").
 		For(&operatorv1alpha1.RootShard{}).
-		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.ConfigMap{}).
-		Owns(&corev1.Service{}).
+		Owns(&deployv1alpha1.CompiledRootShard{}).
 		Owns(&corev1.Secret{}).
 		Owns(&certmanagerv1.Certificate{}).
 		Watches(&operatorv1alpha1.Shard{}, shardHandler).
@@ -173,7 +169,6 @@ func (r *RootShardReconciler) reconcile(ctx context.Context, rootShard *operator
 	}
 
 	ownerRefWrapper := k8creconciling.OwnerRefWrapper(*metav1.NewControllerRef(rootShard, operatorv1alpha1.SchemeGroupVersion.WithKind("RootShard")))
-	revisionLabels := modifier.RelatedRevisionsLabels(ctx, r.Client)
 
 	issuerReconcilers := []reconciling.NamedIssuerReconcilerFactory{
 		rootshard.RootCAIssuerReconciler(rootShard),
@@ -205,7 +200,8 @@ func (r *RootShardReconciler) reconcile(ctx context.Context, rootShard *operator
 		certReconcilers = append(certReconcilers, rootshard.RootCACertificateReconciler(rootShard))
 	}
 
-	if err := reconciling.ReconcileCertificates(ctx, certReconcilers, rootShard.Namespace, r.Client, ownerRefWrapper); err != nil {
+	var certs []*certmanagerv1.Certificate
+	if err := reconciling.ReconcileCertificates(ctx, certReconcilers, rootShard.Namespace, r.Client, ownerRefWrapper, modifier.Capture(&certs)); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -236,6 +232,10 @@ func (r *RootShardReconciler) reconcile(ctx context.Context, rootShard *operator
 		errs = append(errs, err)
 	}
 
+	if err := frontproxy.NewRootShardProxy(rootShard).ReconcileConfig(ctx, r.Client, rootShard.Namespace, modifier.Capture(&certs)); err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile proxy: %w", err))
+	}
+
 	// to correctly configure the cache settings, we need to find the (optional) external
 	// kcp virtual workspace
 	var kcpVW *operatorv1alpha1.VirtualWorkspace
@@ -251,32 +251,14 @@ func (r *RootShardReconciler) reconcile(ctx context.Context, rootShard *operator
 		}
 	}
 
-	// Deployment will be scaled to 0 if bundle annotation is present
-	if vwConfigValid {
+	revisions, ready := util.CertificateRevisions(certs)
+
+	if vwConfigValid && ready {
 		if err := reconciling.ReconcileCompiledRootShards(ctx, []reconciling.NamedCompiledRootShardReconcilerFactory{
-			rootshard.CompiledRootShardReconciler(rootShard, kcpVW, nil),
+			rootshard.CompiledRootShardReconciler(rootShard, kcpVW, util.MutateKeys(revisions, "cert-", "-revision")),
 		}, rootShard.Namespace, r.Client, ownerRefWrapper); err != nil {
 			errs = append(errs, err)
 		}
-
-		if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{
-			rootshard.DeploymentReconciler(rootShard, kcpVW),
-		}, rootShard.Namespace, r.Client, ownerRefWrapper, revisionLabels); err != nil {
-			// Swallow these errors and instead rely on us watching Secrets and re-reconciling whenever they change.
-			if !errors.Is(err, modifier.ErrMountNotFound) {
-				errs = append(errs, err)
-			}
-		}
-	}
-
-	if err := k8creconciling.ReconcileServices(ctx, []k8creconciling.NamedServiceReconcilerFactory{
-		rootshard.ServiceReconciler(rootShard),
-	}, rootShard.Namespace, r.Client, ownerRefWrapper); err != nil {
-		errs = append(errs, err)
-	}
-
-	if err := frontproxy.NewRootShardProxy(rootShard).Reconcile(ctx, r.Client, rootShard.Namespace); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile proxy: %w", err))
 	}
 
 	return conditions, kerrors.NewAggregate(errs)
@@ -294,14 +276,13 @@ func (r *RootShardReconciler) reconcileStatus(ctx context.Context, oldRootShard 
 	// Check if rootshard is bundled (has bundle annotation with Ready bundle)
 	isBundled := bundleCond.Status == metav1.ConditionTrue && bundleCond.Reason == "BundleReady"
 
-	// Only check deployment status if not bundled
+	// Only check availability if not bundled
 	if !isBundled {
-		depKey := types.NamespacedName{Namespace: rootShard.Namespace, Name: resources.GetRootShardDeploymentName(rootShard)}
-		cond, err := util.GetDeploymentAvailableCondition(ctx, r.Client, depKey)
-		if err != nil {
+		compiled := &deployv1alpha1.CompiledRootShard{}
+		if err := r.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(rootShard), compiled); ctrlruntimeclient.IgnoreNotFound(err) != nil {
 			errs = append(errs, err)
 		} else {
-			conditions = append(conditions, cond)
+			conditions = append(conditions, util.GetCompiledAvailableCondition(compiled.Status.Conditions, fmt.Sprintf("CompiledRootShard %s", rootShard.Name)))
 		}
 	}
 

--- a/internal/controller/rootshard/controller_test.go
+++ b/internal/controller/rootshard/controller_test.go
@@ -18,11 +18,14 @@ package rootshard
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -124,6 +127,16 @@ func TestReconciling(t *testing.T) {
 
 			compiled := &deployv1alpha1.CompiledRootShard{}
 			err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(testcase.rootShard), compiled)
+			require.True(t, apierrors.IsNotFound(err))
+
+			require.NoError(t, util.MarkCertificatesReady(ctx, client, namespace))
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(testcase.rootShard),
+			})
+			require.NoError(t, err)
+
+			err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(testcase.rootShard), compiled)
 			require.NoError(t, err)
 			require.Equal(t, testcase.rootShard.Spec, compiled.Spec.RootShard)
 			require.Nil(t, compiled.Spec.VirtualWorkspace)
@@ -131,6 +144,13 @@ func TestReconciling(t *testing.T) {
 			require.Len(t, compiled.OwnerReferences, 1)
 			require.Equal(t, "RootShard", compiled.OwnerReferences[0].Kind)
 			require.Equal(t, testcase.rootShard.Name, compiled.OwnerReferences[0].Name)
+
+			certs := &certmanagerv1.CertificateList{}
+			require.NoError(t, client.List(ctx, certs, ctrlruntimeclient.InNamespace(namespace)))
+			require.NotEmpty(t, certs.Items)
+			for _, cert := range certs.Items {
+				require.Equal(t, "1", compiled.Annotations[fmt.Sprintf("operator.kcp.io/cert-%s-revision", cert.Name)])
+			}
 		})
 	}
 }

--- a/internal/controller/util/util.go
+++ b/internal/controller/util/util.go
@@ -106,6 +106,21 @@ func GetDeploymentAvailableCondition(ctx context.Context, client ctrlruntimeclie
 	}, nil
 }
 
+// GetCompiledAvailableCondition returns the Available condition reported on a compiled resource,
+// or a fallback condition if the compiled resource has not reported availability yet.
+func GetCompiledAvailableCondition(conditions []metav1.Condition, objName string) metav1.Condition {
+	if cond := apimeta.FindStatusCondition(conditions, string(operatorv1alpha1.ConditionTypeAvailable)); cond != nil {
+		return *cond
+	}
+
+	return metav1.Condition{
+		Type:    string(operatorv1alpha1.ConditionTypeAvailable),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(operatorv1alpha1.ConditionReasonDeploymentUnavailable),
+		Message: fmt.Sprintf("%s has not reported availability.", objName),
+	}
+}
+
 func UpdateCondition(conditions []metav1.Condition, newCondition metav1.Condition) []metav1.Condition {
 	if conditions == nil {
 		conditions = make([]metav1.Condition, 0)


### PR DESCRIPTION
This PR is part of a stacked PR that splits kcp-operator's functionality
into two controller groups, `config` and `workload` and adds an
intermediate resource group deploy.operator.kcp.io. The config
controller group prepares and compiles resources into resources of the
group deploy.operator.kcp.io.

The `workload` then realizes the compiled resource into workload
resources (`Deployment` and `Service`).

```release-note
NONE
```

/kind feature
