### PR TITLE
Render Shard workloads from CompiledShard

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/kcp-dev/kcp-operator/internal/controller/bundle"
 	"github.com/kcp-dev/kcp-operator/internal/controller/cacheserver"
 	"github.com/kcp-dev/kcp-operator/internal/controller/compiledrootshard"
+	"github.com/kcp-dev/kcp-operator/internal/controller/compiledshard"
 	"github.com/kcp-dev/kcp-operator/internal/controller/frontproxy"
 	"github.com/kcp-dev/kcp-operator/internal/controller/kubeconfig"
 	kubeconfigrbac "github.com/kcp-dev/kcp-operator/internal/controller/kubeconfig-rbac"
@@ -294,6 +295,13 @@ func setupWorkloadControllers(mgr ctrl.Manager, client ctrlruntimeclient.Client)
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller %s: %w", "CompiledRootShard", err)
+	}
+
+	if err := (&compiledshard.Reconciler{
+		Client: client,
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "CompiledShard", err)
 	}
 
 	return nil

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -104,7 +104,6 @@ rules:
   - frontproxies/finalizers
   - kubeconfigs/finalizers
   - rootshards/finalizers
-  - shards/finalizers
   verbs:
   - update
 - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -44,6 +44,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - deploy.operator.kcp.io
   resources:
   - compiledcacheservers
@@ -63,9 +71,16 @@ rules:
   - deploy.operator.kcp.io
   resources:
   - compiledrootshards/status
+  - compiledshards/status
   verbs:
   - get
   - patch
+  - update
+- apiGroups:
+  - deploy.operator.kcp.io
+  resources:
+  - compiledshards/finalizers
+  verbs:
   - update
 - apiGroups:
   - operator.kcp.io

--- a/internal/client/clients.go
+++ b/internal/client/clients.go
@@ -70,6 +70,36 @@ func NewShardClient(ctx context.Context, c ctrlruntimeclient.Client, shard *oper
 	return newClient(ctx, c, baseUrl, scheme, rootShard)
 }
 
+// NewRootShardClientWithShardCert returns a new client for talking to a kcp root shard using the shards client certificate.
+func NewRootShardClientWithShardCert(ctx context.Context, c ctrlruntimeclient.Client, shard *operatorv1alpha1.Shard, rootShard *operatorv1alpha1.RootShard, cluster logicalcluster.Path, scheme *runtime.Scheme) (ctrlruntimeclient.Client, error) {
+	baseUrl := fmt.Sprintf("https://%s.%s.svc.cluster.local:6443", resources.GetRootShardServiceName(rootShard), rootShard.Namespace)
+
+	if !cluster.Empty() {
+		baseUrl += cluster.RequestPath()
+	}
+
+	caSecret := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: rootShard.Namespace, Name: resources.GetRootShardCAName(rootShard, operatorv1alpha1.ServerCA)}, caSecret); err != nil {
+		return nil, fmt.Errorf("failed to get root shard server CA Secret: %w", err)
+	}
+
+	certSecret := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: shard.Namespace, Name: resources.GetShardCertificateName(shard, operatorv1alpha1.ClientCertificate)}, certSecret); err != nil {
+		return nil, fmt.Errorf("failed to get shard client certificate Secret: %w", err)
+	}
+
+	cfg := &rest.Config{
+		Host: baseUrl,
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData:   caSecret.Data["tls.crt"],
+			CertData: certSecret.Data["tls.crt"],
+			KeyData:  certSecret.Data["tls.key"],
+		},
+	}
+
+	return ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{Scheme: scheme})
+}
+
 func newClient(
 	ctx context.Context,
 	c ctrlruntimeclient.Client,

--- a/internal/controller/compiledshard/controller.go
+++ b/internal/controller/compiledshard/controller.go
@@ -1,0 +1,294 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compiledshard
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	k8creconciling "k8c.io/reconciler/pkg/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kcp-dev/kcp-operator/internal/client"
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	"github.com/kcp-dev/kcp-operator/internal/resources/shard"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+// requeueAfter is the retry delay when a mounted Secret or ConfigMap does not exist yet.
+const requeueAfter = 10 * time.Second
+
+const cleanupFinalizer = "operator.kcp.io/cleanup-shard"
+
+// Reconciler reconciles a CompiledShard object.
+type Reconciler struct {
+	ctrlruntimeclient.Client
+	Scheme *runtime.Scheme
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("compiledshard").
+		For(&deployv1alpha1.CompiledShard{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Complete(r)
+}
+
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledshards,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledshards/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledshards/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=secrets;configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.V(4).Info("Reconciling")
+
+	var compiled deployv1alpha1.CompiledShard
+	if err := r.Get(ctx, req.NamespacedName, &compiled); err != nil {
+		return ctrl.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	if compiled.DeletionTimestamp != nil {
+		return r.handleDeletion(ctx, &compiled)
+	}
+
+	// Ensure the finalizer before any other work.
+	updated, err := r.ensureFinalizer(ctx, &compiled)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if updated {
+		// Will be requeued by the patch event.
+		return ctrl.Result{}, nil
+	}
+
+	result, recErr := r.reconcile(ctx, &compiled)
+	statusErr := r.reconcileStatus(ctx, &compiled)
+
+	return result, kerrors.NewAggregate([]error{recErr, statusErr})
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, compiled *deployv1alpha1.CompiledShard) (ctrl.Result, error) {
+	var (
+		errs    []error
+		requeue bool
+	)
+
+	s := &operatorv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        compiled.Name,
+			Namespace:   compiled.Namespace,
+			Labels:      compiled.Labels,
+			Annotations: compiled.Annotations,
+		},
+		Spec: compiled.Spec.Shard,
+	}
+
+	rootShard := &operatorv1alpha1.RootShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Spec.RootShard.Name,
+			Namespace: compiled.Namespace,
+		},
+		Spec: compiled.Spec.RootShard.Spec,
+	}
+
+	var kcpVW *operatorv1alpha1.VirtualWorkspace
+	if compiled.Spec.VirtualWorkspace != nil {
+		kcpVW = &operatorv1alpha1.VirtualWorkspace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      compiled.Spec.VirtualWorkspace.Name,
+				Namespace: compiled.Namespace,
+			},
+			Spec: compiled.Spec.VirtualWorkspace.Spec,
+		}
+	}
+
+	ownerRef := *metav1.NewControllerRef(compiled, deployv1alpha1.SchemeGroupVersion.WithKind("CompiledShard"))
+	ownerRefWrapper := k8creconciling.OwnerRefWrapper(ownerRef)
+	revisionLabels := modifier.RelatedRevisionsLabels(ctx, r.Client)
+
+	if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{
+		shard.DeploymentReconciler(s, rootShard, kcpVW),
+	}, compiled.Namespace, r.Client, ownerRefWrapper, revisionLabels); err != nil {
+		if errors.Is(err, modifier.ErrMountNotFound) {
+			requeue = true
+		} else {
+			errs = append(errs, err)
+		}
+	}
+
+	if err := k8creconciling.ReconcileServices(ctx, []k8creconciling.NamedServiceReconcilerFactory{
+		shard.ServiceReconciler(s),
+	}, compiled.Namespace, r.Client, ownerRefWrapper); err != nil {
+		errs = append(errs, err)
+	}
+
+	result := ctrl.Result{}
+	if requeue {
+		result.RequeueAfter = requeueAfter
+	}
+
+	return result, kerrors.NewAggregate(errs)
+}
+
+func (r *Reconciler) reconcileStatus(ctx context.Context, oldCompiled *deployv1alpha1.CompiledShard) error {
+	compiled := oldCompiled.DeepCopy()
+
+	s := &operatorv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Name,
+			Namespace: compiled.Namespace,
+		},
+	}
+
+	depKey := types.NamespacedName{Namespace: compiled.Namespace, Name: resources.GetShardDeploymentName(s)}
+	cond, err := util.GetDeploymentAvailableCondition(ctx, r.Client, depKey)
+	if err != nil {
+		return err
+	}
+
+	cond.ObservedGeneration = compiled.Generation
+	compiled.Status.Conditions = util.UpdateCondition(compiled.Status.Conditions, cond)
+
+	compiled.Status.Phase = operatorv1alpha1.ShardPhaseProvisioning
+	if availableCond := apimeta.FindStatusCondition(compiled.Status.Conditions, string(operatorv1alpha1.ConditionTypeAvailable)); availableCond != nil && availableCond.Status == metav1.ConditionTrue {
+		compiled.Status.Phase = operatorv1alpha1.ShardPhaseRunning
+	}
+
+	if !equality.Semantic.DeepEqual(oldCompiled.Status, compiled.Status) {
+		return r.Status().Patch(ctx, compiled, ctrlruntimeclient.MergeFrom(oldCompiled))
+	}
+
+	return nil
+}
+
+// handleDeletion deletes the Deployment and waits until all Pods are gone, then deletes the Shard from the root workspace.
+func (r *Reconciler) handleDeletion(ctx context.Context, compiled *deployv1alpha1.CompiledShard) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	if !slices.Contains(compiled.Finalizers, cleanupFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	s := &operatorv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Name,
+			Namespace: compiled.Namespace,
+		},
+		Spec: compiled.Spec.Shard,
+	}
+
+	rootShard := &operatorv1alpha1.RootShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Spec.RootShard.Name,
+			Namespace: compiled.Namespace,
+		},
+		Spec: compiled.Spec.RootShard.Spec,
+	}
+
+	deployment := &appsv1.Deployment{}
+	err := r.Get(ctx, types.NamespacedName{Namespace: compiled.Namespace, Name: resources.GetShardDeploymentName(s)}, deployment)
+	switch {
+	case err == nil:
+		if deployment.DeletionTimestamp == nil {
+			if err := r.Delete(ctx, deployment); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+	case !apierrors.IsNotFound(err):
+		return ctrl.Result{}, err
+	}
+
+	pods := &corev1.PodList{}
+	if err := r.List(ctx, pods, ctrlruntimeclient.InNamespace(compiled.Namespace), ctrlruntimeclient.MatchingLabels(resources.GetShardResourceLabels(s))); err != nil {
+		return ctrl.Result{}, err
+	}
+	if len(pods.Items) > 0 {
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+	}
+
+	kcpClient, err := client.NewRootShardClientWithShardCert(ctx, r.Client, s, rootShard, logicalcluster.NewPath("root"), r.Scheme)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Without the certificate secrets we cannot talk to the root shard anymore.
+			logger.Info("Certificate secrets are gone, skipping kcp Shard cleanup.")
+			return ctrl.Result{}, r.removeFinalizer(ctx, compiled)
+		}
+		return ctrl.Result{}, err
+	}
+
+	if err := kcpClient.Delete(ctx, &kcpcorev1alpha1.Shard{ObjectMeta: metav1.ObjectMeta{Name: compiled.Name}}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		logger.V(4).Info("kcp Shard object already deleted.")
+	}
+
+	return ctrl.Result{}, r.removeFinalizer(ctx, compiled)
+}
+
+func (r *Reconciler) ensureFinalizer(ctx context.Context, compiled *deployv1alpha1.CompiledShard) (bool, error) {
+	finalizers := sets.New(compiled.GetFinalizers()...)
+	if finalizers.Has(cleanupFinalizer) {
+		return false, nil
+	}
+
+	original := compiled.DeepCopy()
+	finalizers.Insert(cleanupFinalizer)
+	compiled.SetFinalizers(sets.List(finalizers))
+
+	return true, r.Patch(ctx, compiled, ctrlruntimeclient.MergeFrom(original))
+}
+
+func (r *Reconciler) removeFinalizer(ctx context.Context, compiled *deployv1alpha1.CompiledShard) error {
+	finalizers := sets.New(compiled.GetFinalizers()...)
+	if !finalizers.Has(cleanupFinalizer) {
+		return nil
+	}
+
+	original := compiled.DeepCopy()
+	finalizers.Delete(cleanupFinalizer)
+	compiled.SetFinalizers(sets.List(finalizers))
+
+	return r.Patch(ctx, compiled, ctrlruntimeclient.MergeFrom(original))
+}

--- a/internal/controller/compiledshard/controller_test.go
+++ b/internal/controller/compiledshard/controller_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compiledshard
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+func TestReconciling(t *testing.T) {
+	const namespace = "compiled-shard-tests"
+
+	compiled := &deployv1alpha1.CompiledShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shardy",
+			Namespace: namespace,
+		},
+		Spec: deployv1alpha1.CompiledShardSpec{
+			Shard: operatorv1alpha1.ShardSpec{
+				CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+					Etcd: operatorv1alpha1.EtcdConfig{
+						Endpoints: []string{"https://localhost:2379"},
+					},
+				},
+			},
+			RootShard: deployv1alpha1.NamedRootShardSpec{
+				Name: "rooty",
+				Spec: operatorv1alpha1.RootShardSpec{
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "example.kcp.io",
+						Port:     6443,
+					},
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						Etcd: operatorv1alpha1.EtcdConfig{
+							Endpoints: []string{"https://localhost:2379"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s := &operatorv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Name,
+			Namespace: compiled.Namespace,
+		},
+	}
+
+	rootShard := &operatorv1alpha1.RootShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Spec.RootShard.Name,
+			Namespace: compiled.Namespace,
+		},
+	}
+
+	// Secrets mounted into the deployment must exist for the revision-labels modifier.
+	var mountedSecretNames []string
+	for _, ca := range []operatorv1alpha1.CA{
+		operatorv1alpha1.RootCA,
+		operatorv1alpha1.ServerCA,
+		operatorv1alpha1.ServiceAccountCA,
+		operatorv1alpha1.RequestHeaderClientCA,
+		operatorv1alpha1.ClientCA,
+	} {
+		mountedSecretNames = append(mountedSecretNames, resources.GetRootShardCAName(rootShard, ca))
+	}
+	for _, cert := range []operatorv1alpha1.Certificate{
+		operatorv1alpha1.ClientCertificate,
+		operatorv1alpha1.LogicalClusterAdminCertificate,
+		operatorv1alpha1.ExternalLogicalClusterAdminCertificate,
+	} {
+		mountedSecretNames = append(mountedSecretNames, resources.GetShardKubeconfigSecret(s, cert))
+	}
+	for _, cert := range []operatorv1alpha1.Certificate{
+		operatorv1alpha1.ServerCertificate,
+		operatorv1alpha1.ServiceAccountCertificate,
+		operatorv1alpha1.ClientCertificate,
+		operatorv1alpha1.LogicalClusterAdminCertificate,
+		operatorv1alpha1.ExternalLogicalClusterAdminCertificate,
+		operatorv1alpha1.MountsProxyClientCertificate,
+	} {
+		mountedSecretNames = append(mountedSecretNames, resources.GetShardCertificateName(s, cert))
+	}
+
+	objects := []ctrlruntimeclient.Object{compiled}
+	for _, name := range mountedSecretNames {
+		objects = append(objects, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		})
+	}
+
+	scheme := util.GetTestScheme()
+
+	client := ctrlruntimefakeclient.
+		NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(compiled).
+		Build()
+
+	ctx := context.Background()
+
+	controllerReconciler := &Reconciler{
+		Client: client,
+		Scheme: client.Scheme(),
+	}
+
+	// Reconcile twice, the first adds the new finalizer
+	_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(compiled),
+	})
+	require.NoError(t, err)
+
+	_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(compiled),
+	})
+	require.NoError(t, err)
+
+	deployment := &appsv1.Deployment{}
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKey{
+		Name:      resources.GetShardDeploymentName(s),
+		Namespace: namespace,
+	}, deployment)
+	require.NoError(t, err)
+	require.Len(t, deployment.OwnerReferences, 1)
+	require.Equal(t, "CompiledShard", deployment.OwnerReferences[0].Kind)
+	require.Equal(t, compiled.Name, deployment.OwnerReferences[0].Name)
+
+	service := &corev1.Service{}
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKey{
+		Name:      resources.GetShardServiceName(s),
+		Namespace: namespace,
+	}, service)
+	require.NoError(t, err)
+	require.Len(t, service.OwnerReferences, 1)
+	require.Equal(t, "CompiledShard", service.OwnerReferences[0].Kind)
+	require.Equal(t, compiled.Name, service.OwnerReferences[0].Name)
+
+	updated := &deployv1alpha1.CompiledShard{}
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(compiled), updated)
+	require.NoError(t, err)
+	availableCond := apimeta.FindStatusCondition(updated.Status.Conditions, string(operatorv1alpha1.ConditionTypeAvailable))
+	require.NotNil(t, availableCond)
+	require.Equal(t, metav1.ConditionFalse, availableCond.Status)
+	require.Equal(t, operatorv1alpha1.ShardPhaseProvisioning, updated.Status.Phase)
+}

--- a/internal/controller/shard/controller.go
+++ b/internal/controller/shard/controller.go
@@ -18,45 +18,35 @@ package shard
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"slices"
 	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	"github.com/kcp-dev/logicalcluster/v3"
-	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	k8creconciling "k8c.io/reconciler/pkg/reconciling"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/kcp-dev/kcp-operator/internal/client"
 	bundlehelper "github.com/kcp-dev/kcp-operator/internal/controller/bundle"
 	"github.com/kcp-dev/kcp-operator/internal/controller/util"
 	"github.com/kcp-dev/kcp-operator/internal/metrics"
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
 	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
-	"github.com/kcp-dev/kcp-operator/internal/resources"
 	"github.com/kcp-dev/kcp-operator/internal/resources/shard"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
-
-const cleanupFinalizer = "operator.kcp.io/cleanup-shard"
 
 // ShardReconciler reconciles a Shard object
 type ShardReconciler struct {
@@ -107,9 +97,8 @@ func (r *ShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("shard").
 		For(&operatorv1alpha1.Shard{}).
-		Owns(&appsv1.Deployment{}).
+		Owns(&deployv1alpha1.CompiledShard{}).
 		Owns(&corev1.Secret{}).
-		Owns(&corev1.Service{}).
 		Owns(&certmanagerv1.Certificate{}).
 		Watches(&operatorv1alpha1.RootShard{}, rootShardHandler).
 		Watches(&operatorv1alpha1.VirtualWorkspace{}, vwHandler).
@@ -118,7 +107,6 @@ func (r *ShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=shards,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=operator.kcp.io,resources=shards/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=operator.kcp.io,resources=shards/finalizers,verbs=update
 // +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledshards,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
@@ -160,14 +148,7 @@ func (r *ShardReconciler) reconcile(ctx context.Context, s *operatorv1alpha1.Sha
 	)
 
 	if s.DeletionTimestamp != nil {
-		return r.handleDeletion(ctx, s)
-	}
-
-	// Ensure finalizer before any other work
-	if updated, err := r.ensureFinalizer(ctx, s); err != nil {
-		return conditions, fmt.Errorf("failed to ensure cleanup finalizer: %w", err)
-	} else if updated {
-		return conditions, nil // Will be requeued
+		return conditions, nil
 	}
 
 	// Ensure Bundle object exists if annotation is present
@@ -183,7 +164,6 @@ func (r *ShardReconciler) reconcile(ctx context.Context, s *operatorv1alpha1.Sha
 	}
 
 	ownerRefWrapper := k8creconciling.OwnerRefWrapper(*metav1.NewControllerRef(s, operatorv1alpha1.SchemeGroupVersion.WithKind("Shard")))
-	revisionLabels := modifier.RelatedRevisionsLabels(ctx, r.Client)
 
 	certReconcilers := []reconciling.NamedCertificateReconcilerFactory{
 		shard.ServerCertificateReconciler(s, rootShard),
@@ -241,28 +221,12 @@ func (r *ShardReconciler) reconcile(ctx context.Context, s *operatorv1alpha1.Sha
 
 	revisions, ready := util.CertificateRevisions(certs)
 
-	// Deployment will be scaled to 0 if bundle annotation is present
 	if vwConfigValid && ready {
 		if err := reconciling.ReconcileCompiledShards(ctx, []reconciling.NamedCompiledShardReconcilerFactory{
 			shard.CompiledShardReconciler(s, rootShard, kcpVW, util.MutateKeys(revisions, "cert-", "-revision")),
 		}, s.Namespace, r.Client, ownerRefWrapper); err != nil {
 			errs = append(errs, err)
 		}
-
-		if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{
-			shard.DeploymentReconciler(s, rootShard, kcpVW),
-		}, s.Namespace, r.Client, ownerRefWrapper, revisionLabels); err != nil {
-			// Swallow these errors and instead rely on us watching Secrets and re-reconciling whenever they change.
-			if !errors.Is(err, modifier.ErrMountNotFound) {
-				errs = append(errs, err)
-			}
-		}
-	}
-
-	if err := k8creconciling.ReconcileServices(ctx, []k8creconciling.NamedServiceReconcilerFactory{
-		shard.ServiceReconciler(s),
-	}, s.Namespace, r.Client, ownerRefWrapper); err != nil {
-		errs = append(errs, err)
 	}
 
 	return conditions, kerrors.NewAggregate(errs)
@@ -280,14 +244,13 @@ func (r *ShardReconciler) reconcileStatus(ctx context.Context, oldShard *operato
 	// Check if shard is bundled (has bundle annotation with Ready bundle)
 	isBundled := bundleCond.Status == metav1.ConditionTrue && bundleCond.Reason == "BundleReady"
 
-	// Only check deployment status if not bundled
+	// Only check availability if not bundled
 	if !isBundled {
-		depKey := types.NamespacedName{Namespace: newShard.Namespace, Name: resources.GetShardDeploymentName(newShard)}
-		cond, err := util.GetDeploymentAvailableCondition(ctx, r.Client, depKey)
-		if err != nil {
+		compiled := &deployv1alpha1.CompiledShard{}
+		if err := r.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(newShard), compiled); ctrlruntimeclient.IgnoreNotFound(err) != nil {
 			errs = append(errs, err)
 		} else {
-			conditions = append(conditions, cond)
+			conditions = append(conditions, util.GetCompiledAvailableCondition(compiled.Status.Conditions, fmt.Sprintf("CompiledShard %s", newShard.Name)))
 		}
 	}
 
@@ -328,78 +291,4 @@ func (r *ShardReconciler) reconcileStatus(ctx context.Context, oldShard *operato
 	}
 
 	return kerrors.NewAggregate(errs)
-}
-
-func (r *ShardReconciler) handleDeletion(ctx context.Context, s *operatorv1alpha1.Shard) ([]metav1.Condition, error) {
-	logger := log.FromContext(ctx)
-
-	if !slices.Contains(s.Finalizers, cleanupFinalizer) {
-		return nil, nil
-	}
-
-	// Fetch RootShard
-	cond, rootShard := util.FetchRootShard(ctx, r.Client, s.Namespace, s.Spec.RootShard.Reference)
-	if rootShard == nil {
-		logger.Info("RootShard not found, cannot clean up kcp Shard object", "condition", cond.Message)
-		// Remove finalizer anyway - we can't clean up without the root shard
-		if err := r.removeFinalizer(ctx, s); err != nil {
-			return []metav1.Condition{cond}, fmt.Errorf("failed to remove finalizer: %w", err)
-		}
-		return []metav1.Condition{cond}, nil
-	}
-
-	// Create client to root shard
-	kcpClient, err := client.NewRootShardClient(ctx, r.Client, rootShard, logicalcluster.NewPath("root"), r.Scheme)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create root shard client: %w", err)
-	}
-
-	// Delete the kcp Shard object
-	kcpShard := &kcpcorev1alpha1.Shard{}
-	kcpShard.Name = s.Name
-
-	logger.Info("Deleting kcp Shard object from root workspace", "name", s.Name)
-	if err := kcpClient.Delete(ctx, kcpShard); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("failed to delete kcp Shard: %w", err)
-		}
-		logger.V(2).Info("kcp Shard object already deleted")
-	}
-
-	// Remove finalizer
-	if err := r.removeFinalizer(ctx, s); err != nil {
-		return nil, fmt.Errorf("failed to remove finalizer: %w", err)
-	}
-
-	return nil, nil
-}
-
-func (r *ShardReconciler) ensureFinalizer(ctx context.Context, s *operatorv1alpha1.Shard) (bool, error) {
-	finalizers := sets.New(s.GetFinalizers()...)
-	if finalizers.Has(cleanupFinalizer) {
-		return false, nil
-	}
-
-	original := s.DeepCopy()
-	finalizers.Insert(cleanupFinalizer)
-	s.SetFinalizers(sets.List(finalizers))
-
-	if err := r.Patch(ctx, s, ctrlruntimeclient.MergeFrom(original)); err != nil {
-		return false, err
-	}
-
-	return true, nil
-}
-
-func (r *ShardReconciler) removeFinalizer(ctx context.Context, s *operatorv1alpha1.Shard) error {
-	finalizers := sets.New(s.GetFinalizers()...)
-	if !finalizers.Has(cleanupFinalizer) {
-		return nil
-	}
-
-	original := s.DeepCopy()
-	finalizers.Delete(cleanupFinalizer)
-	s.SetFinalizers(sets.List(finalizers))
-
-	return r.Patch(ctx, s, ctrlruntimeclient.MergeFrom(original))
 }


### PR DESCRIPTION
This PR is part of a stacked PR that splits kcp-operator's functionality
into two controller groups, `config` and `workload` and adds an
intermediate resource group deploy.operator.kcp.io. The config
controller group prepares and compiles resources into resources of the
group deploy.operator.kcp.io.

The `workload` then realizes the compiled resource into workload
resources (`Deployment` and `Service`).


```release-note
NONE
```

/kind feature

