### PR TITLE
Render CacheServer workloads from CompiledCacheServer

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/kcp-dev/kcp-operator/internal/config"
 	"github.com/kcp-dev/kcp-operator/internal/controller/bundle"
 	"github.com/kcp-dev/kcp-operator/internal/controller/cacheserver"
+	"github.com/kcp-dev/kcp-operator/internal/controller/compiledcacheserver"
 	"github.com/kcp-dev/kcp-operator/internal/controller/compiledrootshard"
 	"github.com/kcp-dev/kcp-operator/internal/controller/compiledshard"
 	"github.com/kcp-dev/kcp-operator/internal/controller/frontproxy"
@@ -302,6 +303,13 @@ func setupWorkloadControllers(mgr ctrl.Manager, client ctrlruntimeclient.Client)
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller %s: %w", "CompiledShard", err)
+	}
+
+	if err := (&compiledcacheserver.Reconciler{
+		Client: client,
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "CompiledCacheServer", err)
 	}
 
 	return nil

--- a/internal/controller/cacheserver/controller.go
+++ b/internal/controller/cacheserver/controller.go
@@ -18,12 +18,10 @@ package cacheserver
 
 import (
 	"context"
-	"errors"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	k8creconciling "k8c.io/reconciler/pkg/reconciling"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,6 +33,7 @@ import (
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
 	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
 	"github.com/kcp-dev/kcp-operator/internal/resources/cacheserver"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -48,9 +47,8 @@ func (r *CacheServerReconciler) SetupWithManager(mgr ctrlruntime.Manager) error 
 	return ctrlruntime.NewControllerManagedBy(mgr).
 		Named("cache-server").
 		For(&operatorv1alpha1.CacheServer{}).
-		Owns(&appsv1.Deployment{}).
+		Owns(&deployv1alpha1.CompiledCacheServer{}).
 		Owns(&corev1.Secret{}).
-		Owns(&corev1.Service{}).
 		Owns(&certmanagerv1.Certificate{}).
 		Complete(r)
 }
@@ -87,7 +85,6 @@ func (r *CacheServerReconciler) Reconcile(ctx context.Context, req ctrlruntime.R
 
 func (r *CacheServerReconciler) reconcile(ctx context.Context, server *operatorv1alpha1.CacheServer) error {
 	ownerRefWrapper := k8creconciling.OwnerRefWrapper(*metav1.NewControllerRef(server, operatorv1alpha1.SchemeGroupVersion.WithKind("CacheServer")))
-	revisionLabels := modifier.RelatedRevisionsLabels(ctx, r.Client)
 
 	certReconcilers := []reconciling.NamedCertificateReconcilerFactory{
 		cacheserver.RootCACertificateReconciler(server),
@@ -119,25 +116,6 @@ func (r *CacheServerReconciler) reconcile(ctx context.Context, server *operatorv
 
 	if err := reconciling.ReconcileCompiledCacheServers(ctx, []reconciling.NamedCompiledCacheServerReconcilerFactory{
 		cacheserver.CompiledCacheServerReconciler(server, util.MutateKeys(revisions, "cert-", "-revision")),
-	}, server.Namespace, r.Client, ownerRefWrapper); err != nil {
-		return err
-	}
-
-	// This will fail as long as some of the referenced Secrets/ConfigMaps do not exist yet. We rely on
-	// requeueing to eventually get there in the end. Importantly, reconciling Deployments has to happen
-	// after all Secrets have been reconciled.
-	if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{
-		cacheserver.DeploymentReconciler(server),
-	}, server.Namespace, r.Client, ownerRefWrapper, revisionLabels); err != nil {
-		// Swallow these errors and instead rely on us watching Secrets and re-reconciling whenever they change.
-		if errors.Is(err, modifier.ErrMountNotFound) {
-			return nil
-		}
-		return err
-	}
-
-	if err := k8creconciling.ReconcileServices(ctx, []k8creconciling.NamedServiceReconcilerFactory{
-		cacheserver.ServiceReconciler(server),
 	}, server.Namespace, r.Client, ownerRefWrapper); err != nil {
 		return err
 	}

--- a/internal/controller/compiledcacheserver/controller.go
+++ b/internal/controller/compiledcacheserver/controller.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compiledcacheserver
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	k8creconciling "k8c.io/reconciler/pkg/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
+	"github.com/kcp-dev/kcp-operator/internal/resources/cacheserver"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+// requeueAfter is the retry delay when a mounted Secret or ConfigMap does not exist yet.
+const requeueAfter = 10 * time.Second
+
+// Reconciler reconciles a CompiledCacheServer object.
+type Reconciler struct {
+	ctrlruntimeclient.Client
+	Scheme *runtime.Scheme
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("compiledcacheserver").
+		For(&deployv1alpha1.CompiledCacheServer{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Complete(r)
+}
+
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledcacheservers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=secrets;configmaps,verbs=get;list;watch
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.V(4).Info("Reconciling")
+
+	var compiled deployv1alpha1.CompiledCacheServer
+	if err := r.Get(ctx, req.NamespacedName, &compiled); err != nil {
+		return ctrl.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	if compiled.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	return r.reconcile(ctx, &compiled)
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, compiled *deployv1alpha1.CompiledCacheServer) (ctrl.Result, error) {
+	var (
+		errs    []error
+		requeue bool
+	)
+
+	server := &operatorv1alpha1.CacheServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        compiled.Name,
+			Namespace:   compiled.Namespace,
+			Labels:      compiled.Labels,
+			Annotations: compiled.Annotations,
+		},
+		Spec: compiled.Spec.CacheServer,
+	}
+
+	ownerRef := *metav1.NewControllerRef(compiled, deployv1alpha1.SchemeGroupVersion.WithKind("CompiledCacheServer"))
+	ownerRefWrapper := k8creconciling.OwnerRefWrapper(ownerRef)
+
+	revisionLabels := modifier.RelatedRevisionsLabels(ctx, r.Client)
+
+	if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{
+		cacheserver.DeploymentReconciler(server),
+	}, compiled.Namespace, r.Client, ownerRefWrapper, revisionLabels); err != nil {
+		if errors.Is(err, modifier.ErrMountNotFound) {
+			requeue = true
+		} else {
+			errs = append(errs, err)
+		}
+	}
+
+	if err := k8creconciling.ReconcileServices(ctx, []k8creconciling.NamedServiceReconcilerFactory{
+		cacheserver.ServiceReconciler(server),
+	}, compiled.Namespace, r.Client, ownerRefWrapper); err != nil {
+		errs = append(errs, err)
+	}
+
+	result := ctrl.Result{}
+	if requeue {
+		result.RequeueAfter = requeueAfter
+	}
+
+	return result, kerrors.NewAggregate(errs)
+}

--- a/internal/controller/compiledcacheserver/controller_test.go
+++ b/internal/controller/compiledcacheserver/controller_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compiledcacheserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+func TestReconciling(t *testing.T) {
+	const namespace = "compiled-cacheserver-tests"
+
+	compiled := &deployv1alpha1.CompiledCacheServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cachy",
+			Namespace: namespace,
+		},
+		Spec: deployv1alpha1.CompiledCacheServerSpec{
+			CacheServer: operatorv1alpha1.CacheServerSpec{
+				Certificates: operatorv1alpha1.Certificates{
+					IssuerRef: &operatorv1alpha1.ObjectReference{
+						Group: "cert-manager.io",
+						Kind:  "Issuer",
+						Name:  "test",
+					},
+				},
+			},
+		},
+	}
+
+	server := &operatorv1alpha1.CacheServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Name,
+			Namespace: compiled.Namespace,
+		},
+	}
+
+	// Secrets mounted into the deployment must exist for the revision-labels modifier.
+	mountedSecretNames := []string{
+		resources.GetCacheServerCertificateName(server, operatorv1alpha1.ServerCertificate),
+		resources.GetCacheServerCAName(server.Name, operatorv1alpha1.RootCA),
+	}
+
+	objects := []ctrlruntimeclient.Object{compiled}
+	for _, name := range mountedSecretNames {
+		objects = append(objects, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		})
+	}
+
+	scheme := util.GetTestScheme()
+
+	client := ctrlruntimefakeclient.
+		NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+
+	ctx := context.Background()
+
+	controllerReconciler := &Reconciler{
+		Client: client,
+		Scheme: client.Scheme(),
+	}
+
+	_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(compiled),
+	})
+	require.NoError(t, err)
+
+	deployment := &appsv1.Deployment{}
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKey{
+		Name:      resources.GetCacheServerDeploymentName(server),
+		Namespace: namespace,
+	}, deployment)
+	require.NoError(t, err)
+	require.Len(t, deployment.OwnerReferences, 1)
+	require.Equal(t, "CompiledCacheServer", deployment.OwnerReferences[0].Kind)
+	require.Equal(t, compiled.Name, deployment.OwnerReferences[0].Name)
+
+	service := &corev1.Service{}
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKey{
+		Name:      resources.GetCacheServerServiceName(server),
+		Namespace: namespace,
+	}, service)
+	require.NoError(t, err)
+	require.Len(t, service.OwnerReferences, 1)
+	require.Equal(t, "CompiledCacheServer", service.OwnerReferences[0].Kind)
+	require.Equal(t, compiled.Name, service.OwnerReferences[0].Name)
+}


### PR DESCRIPTION
This PR is part of a stacked PR that splits kcp-operator's functionality
into two controller groups, `config` and `workload` and adds an
intermediate resource group deploy.operator.kcp.io. The config
controller group prepares and compiles resources into resources of the
group deploy.operator.kcp.io.

The `workload` then realizes the compiled resource into workload
resources (`Deployment` and `Service`).

```release-note
NONE
```

/kind feature

