### PR TITLE
Render FrontProxy workloads from CompiledFrontProxy

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/kcp-dev/kcp-operator/internal/controller/bundle"
 	"github.com/kcp-dev/kcp-operator/internal/controller/cacheserver"
 	"github.com/kcp-dev/kcp-operator/internal/controller/compiledcacheserver"
+	"github.com/kcp-dev/kcp-operator/internal/controller/compiledfrontproxy"
 	"github.com/kcp-dev/kcp-operator/internal/controller/compiledrootshard"
 	"github.com/kcp-dev/kcp-operator/internal/controller/compiledshard"
 	"github.com/kcp-dev/kcp-operator/internal/controller/frontproxy"
@@ -310,6 +311,13 @@ func setupWorkloadControllers(mgr ctrl.Manager, client ctrlruntimeclient.Client)
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller %s: %w", "CompiledCacheServer", err)
+	}
+
+	if err := (&compiledfrontproxy.Reconciler{
+		Client: client,
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "CompiledFrontProxy", err)
 	}
 
 	return nil

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -70,6 +70,7 @@ rules:
 - apiGroups:
   - deploy.operator.kcp.io
   resources:
+  - compiledfrontproxies/status
   - compiledrootshards/status
   - compiledshards/status
   verbs:

--- a/internal/controller/compiledfrontproxy/controller.go
+++ b/internal/controller/compiledfrontproxy/controller.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compiledfrontproxy
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	"github.com/kcp-dev/kcp-operator/internal/resources/frontproxy"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+// requeueAfter is the retry delay when a mounted Secret or ConfigMap does not exist yet.
+const requeueAfter = 10 * time.Second
+
+// Reconciler reconciles a CompiledFrontProxy object.
+type Reconciler struct {
+	ctrlruntimeclient.Client
+	Scheme *runtime.Scheme
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("compiledfrontproxy").
+		For(&deployv1alpha1.CompiledFrontProxy{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.ConfigMap{}).
+		Complete(r)
+}
+
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledfrontproxies,verbs=get;list;watch
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledfrontproxies/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=services;configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.V(4).Info("Reconciling")
+
+	var compiled deployv1alpha1.CompiledFrontProxy
+	if err := r.Get(ctx, req.NamespacedName, &compiled); err != nil {
+		return ctrl.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	if compiled.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	result, recErr := r.reconcile(ctx, &compiled)
+	statusErr := r.reconcileStatus(ctx, &compiled)
+
+	return result, kerrors.NewAggregate([]error{recErr, statusErr})
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, compiled *deployv1alpha1.CompiledFrontProxy) (ctrl.Result, error) {
+	frontProxy := &operatorv1alpha1.FrontProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        compiled.Name,
+			Namespace:   compiled.Namespace,
+			Labels:      compiled.Labels,
+			Annotations: compiled.Annotations,
+		},
+		Spec: compiled.Spec.FrontProxy,
+	}
+
+	rootShard := &operatorv1alpha1.RootShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Spec.RootShard.Name,
+			Namespace: compiled.Namespace,
+		},
+		Spec: compiled.Spec.RootShard.Spec,
+	}
+
+	ownerRef := *metav1.NewControllerRef(compiled, deployv1alpha1.SchemeGroupVersion.WithKind("CompiledFrontProxy"))
+
+	requeue, err := frontproxy.NewFrontProxy(frontProxy, rootShard).ReconcileWorkload(ctx, r.Client, compiled.Namespace, ownerRef)
+
+	result := ctrl.Result{}
+	if requeue {
+		result.RequeueAfter = requeueAfter
+	}
+
+	return result, err
+}
+
+func (r *Reconciler) reconcileStatus(ctx context.Context, oldCompiled *deployv1alpha1.CompiledFrontProxy) error {
+	compiled := oldCompiled.DeepCopy()
+
+	frontProxy := &operatorv1alpha1.FrontProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Name,
+			Namespace: compiled.Namespace,
+		},
+	}
+
+	depKey := types.NamespacedName{Namespace: compiled.Namespace, Name: resources.GetFrontProxyDeploymentName(frontProxy)}
+	cond, err := util.GetDeploymentAvailableCondition(ctx, r.Client, depKey)
+	if err != nil {
+		return err
+	}
+
+	cond.ObservedGeneration = compiled.Generation
+	compiled.Status.Conditions = util.UpdateCondition(compiled.Status.Conditions, cond)
+
+	compiled.Status.Phase = operatorv1alpha1.FrontProxyPhaseProvisioning
+	if availableCond := apimeta.FindStatusCondition(compiled.Status.Conditions, string(operatorv1alpha1.ConditionTypeAvailable)); availableCond != nil && availableCond.Status == metav1.ConditionTrue {
+		compiled.Status.Phase = operatorv1alpha1.FrontProxyPhaseRunning
+	}
+
+	if !equality.Semantic.DeepEqual(oldCompiled.Status, compiled.Status) {
+		return r.Status().Patch(ctx, compiled, ctrlruntimeclient.MergeFrom(oldCompiled))
+	}
+
+	return nil
+}

--- a/internal/controller/compiledfrontproxy/controller_test.go
+++ b/internal/controller/compiledfrontproxy/controller_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compiledfrontproxy
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+func TestReconciling(t *testing.T) {
+	namespace := "compiled-frontproxy-tests"
+
+	compiled := &deployv1alpha1.CompiledFrontProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fronty",
+			Namespace: namespace,
+		},
+		Spec: deployv1alpha1.CompiledFrontProxySpec{
+			FrontProxy: operatorv1alpha1.FrontProxySpec{},
+			RootShard: deployv1alpha1.NamedRootShardSpec{
+				Name: "rooty",
+				Spec: operatorv1alpha1.RootShardSpec{
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "example.kcp.io",
+						Port:     6443,
+					},
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						Etcd: operatorv1alpha1.EtcdConfig{
+							Endpoints: []string{"https://localhost:2379"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	frontProxy := &operatorv1alpha1.FrontProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Name,
+			Namespace: namespace,
+		},
+	}
+	rootShard := &operatorv1alpha1.RootShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Spec.RootShard.Name,
+			Namespace: namespace,
+		},
+	}
+
+	// Secrets mounted into the deployment must exist for the revision-labels modifier.
+	mountedSecretNames := []string{
+		resources.GetFrontProxyDynamicKubeconfigName(rootShard, frontProxy),
+		resources.GetFrontProxyCertificateName(rootShard, frontProxy, operatorv1alpha1.KubeconfigCertificate),
+		resources.GetFrontProxyCertificateName(rootShard, frontProxy, operatorv1alpha1.ServerCertificate),
+		resources.GetFrontProxyCertificateName(rootShard, frontProxy, operatorv1alpha1.RequestHeaderClientCertificate),
+		resources.GetRootShardCAName(rootShard, operatorv1alpha1.RootCA),
+		resources.GetRootShardCAName(rootShard, operatorv1alpha1.RequestHeaderClientCA),
+		fmt.Sprintf("%s-merged-client-ca", frontProxy.Name),
+	}
+
+	objects := []ctrlruntimeclient.Object{compiled}
+	for _, name := range mountedSecretNames {
+		objects = append(objects, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		})
+	}
+
+	scheme := util.GetTestScheme()
+	client := ctrlruntimefakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(compiled).
+		Build()
+
+	ctx := context.Background()
+	reconciler := &Reconciler{
+		Client: client,
+		Scheme: client.Scheme(),
+	}
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(compiled)})
+	require.NoError(t, err)
+
+	var deployment appsv1.Deployment
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: resources.GetFrontProxyDeploymentName(frontProxy), Namespace: namespace}, &deployment)
+	require.NoError(t, err)
+	require.Len(t, deployment.OwnerReferences, 1)
+	require.Equal(t, "CompiledFrontProxy", deployment.OwnerReferences[0].Kind)
+	require.Equal(t, compiled.Name, deployment.OwnerReferences[0].Name)
+
+	var service corev1.Service
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: resources.GetFrontProxyServiceName(frontProxy), Namespace: namespace}, &service)
+	require.NoError(t, err)
+	require.Len(t, service.OwnerReferences, 1)
+	require.Equal(t, "CompiledFrontProxy", service.OwnerReferences[0].Kind)
+	require.Equal(t, compiled.Name, service.OwnerReferences[0].Name)
+
+	var configMap corev1.ConfigMap
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: resources.GetFrontProxyConfigName(frontProxy), Namespace: namespace}, &configMap)
+	require.NoError(t, err)
+	require.Len(t, configMap.OwnerReferences, 1)
+	require.Equal(t, "CompiledFrontProxy", configMap.OwnerReferences[0].Kind)
+	require.Equal(t, compiled.Name, configMap.OwnerReferences[0].Name)
+
+	var updated deployv1alpha1.CompiledFrontProxy
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(compiled), &updated)
+	require.NoError(t, err)
+	availableCond := apimeta.FindStatusCondition(updated.Status.Conditions, string(operatorv1alpha1.ConditionTypeAvailable))
+	require.NotNil(t, availableCond)
+	require.Equal(t, metav1.ConditionFalse, availableCond.Status)
+	require.Equal(t, operatorv1alpha1.FrontProxyPhaseProvisioning, updated.Status.Phase)
+}

--- a/internal/controller/frontproxy/controller.go
+++ b/internal/controller/frontproxy/controller.go
@@ -24,13 +24,11 @@ import (
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	k8creconciling "k8c.io/reconciler/pkg/reconciling"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -43,8 +41,9 @@ import (
 	"github.com/kcp-dev/kcp-operator/internal/controller/util"
 	"github.com/kcp-dev/kcp-operator/internal/metrics"
 	"github.com/kcp-dev/kcp-operator/internal/reconciling"
-	"github.com/kcp-dev/kcp-operator/internal/resources"
+	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
 	"github.com/kcp-dev/kcp-operator/internal/resources/frontproxy"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -78,10 +77,8 @@ func (r *FrontProxyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("frontproxy").
 		For(&operatorv1alpha1.FrontProxy{}).
-		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.ConfigMap{}).
+		Owns(&deployv1alpha1.CompiledFrontProxy{}).
 		Owns(&corev1.Secret{}).
-		Owns(&corev1.Service{}).
 		Owns(&certmanagerv1.Certificate{}).
 		Watches(&operatorv1alpha1.RootShard{}, rootShardHandler).
 		Complete(r)
@@ -151,15 +148,20 @@ func (r *FrontProxyReconciler) reconcile(ctx context.Context, frontProxy *operat
 
 	ownerRefWrapper := k8creconciling.OwnerRefWrapper(*metav1.NewControllerRef(frontProxy, operatorv1alpha1.SchemeGroupVersion.WithKind("FrontProxy")))
 
-	if err := reconciling.ReconcileCompiledFrontProxys(ctx, []reconciling.NamedCompiledFrontProxyReconcilerFactory{
-		frontproxy.CompiledFrontProxyReconciler(frontProxy, rootShard, nil),
-	}, frontProxy.Namespace, r.Client, ownerRefWrapper); err != nil {
-		errs = append(errs, err)
+	var certs []*certmanagerv1.Certificate
+	if err := fpReconciler.ReconcileConfig(ctx, r.Client, frontProxy.Namespace, modifier.Capture(&certs)); err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile: %w", err))
 	}
 
-	// Deployment will be scaled to 0 if bundle annotation is present
-	if err := fpReconciler.Reconcile(ctx, r.Client, frontProxy.Namespace); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile: %w", err))
+	revisions, ready := util.CertificateRevisions(certs)
+	if !ready {
+		return conditions, kerrors.NewAggregate(errs)
+	}
+
+	if err := reconciling.ReconcileCompiledFrontProxys(ctx, []reconciling.NamedCompiledFrontProxyReconcilerFactory{
+		frontproxy.CompiledFrontProxyReconciler(frontProxy, rootShard, util.MutateKeys(revisions, "cert-", "-revision")),
+	}, frontProxy.Namespace, r.Client, ownerRefWrapper); err != nil {
+		errs = append(errs, err)
 	}
 
 	return conditions, kerrors.NewAggregate(errs)
@@ -176,14 +178,13 @@ func (r *FrontProxyReconciler) reconcileStatus(ctx context.Context, oldFrontProx
 	// Check if frontproxy is bundled (has bundle annotation with Ready bundle)
 	isBundled := bundleCond.Status == metav1.ConditionTrue && bundleCond.Reason == "BundleReady"
 
-	// Only check deployment status if not bundled
+	// Only check availability if not bundled
 	if !isBundled {
-		depKey := types.NamespacedName{Namespace: frontProxy.Namespace, Name: resources.GetFrontProxyDeploymentName(frontProxy)}
-		cond, err := util.GetDeploymentAvailableCondition(ctx, r.Client, depKey)
-		if err != nil {
+		compiled := &deployv1alpha1.CompiledFrontProxy{}
+		if err := r.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(frontProxy), compiled); ctrlruntimeclient.IgnoreNotFound(err) != nil {
 			errs = append(errs, err)
 		} else {
-			conditions = append(conditions, cond)
+			conditions = append(conditions, util.GetCompiledAvailableCondition(compiled.Status.Conditions, fmt.Sprintf("CompiledFrontProxy %s", frontProxy.Name)))
 		}
 	}
 

--- a/internal/controller/frontproxy/controller_test.go
+++ b/internal/controller/frontproxy/controller_test.go
@@ -18,11 +18,14 @@ package frontproxy
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -151,6 +154,16 @@ func TestReconciling(t *testing.T) {
 
 			compiled := &deployv1alpha1.CompiledFrontProxy{}
 			err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(testcase.frontProxy), compiled)
+			require.True(t, apierrors.IsNotFound(err))
+
+			require.NoError(t, util.MarkCertificatesReady(ctx, client, namespace))
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(testcase.frontProxy),
+			})
+			require.NoError(t, err)
+
+			err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(testcase.frontProxy), compiled)
 			require.NoError(t, err)
 			require.Equal(t, testcase.frontProxy.Spec, compiled.Spec.FrontProxy)
 			require.Equal(t, testcase.rootShard.Name, compiled.Spec.RootShard.Name)
@@ -160,6 +173,13 @@ func TestReconciling(t *testing.T) {
 			require.Len(t, compiled.OwnerReferences, 1)
 			require.Equal(t, "FrontProxy", compiled.OwnerReferences[0].Kind)
 			require.Equal(t, testcase.frontProxy.Name, compiled.OwnerReferences[0].Name)
+
+			certs := &certmanagerv1.CertificateList{}
+			require.NoError(t, client.List(ctx, certs, ctrlruntimeclient.InNamespace(namespace)))
+			require.NotEmpty(t, certs.Items)
+			for _, cert := range certs.Items {
+				require.Equal(t, "1", compiled.Annotations[fmt.Sprintf("operator.kcp.io/cert-%s-revision", cert.Name)])
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR is part of a stacked PR that splits kcp-operator's functionality
into two controller groups, `config` and `workload` and adds an
intermediate resource group deploy.operator.kcp.io. The config
controller group prepares and compiles resources into resources of the
group deploy.operator.kcp.io.

The `workload` then realizes the compiled resource into workload
resources (`Deployment` and `Service`).

```release-note
NONE
```

/kind feature

