### PR TITLE
Render VirtualWorkspace workloads from CompiledVirtualWorkspace

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/kcp-dev/kcp-operator/internal/controller/compiledfrontproxy"
 	"github.com/kcp-dev/kcp-operator/internal/controller/compiledrootshard"
 	"github.com/kcp-dev/kcp-operator/internal/controller/compiledshard"
+	"github.com/kcp-dev/kcp-operator/internal/controller/compiledvirtualworkspace"
 	"github.com/kcp-dev/kcp-operator/internal/controller/frontproxy"
 	"github.com/kcp-dev/kcp-operator/internal/controller/kubeconfig"
 	kubeconfigrbac "github.com/kcp-dev/kcp-operator/internal/controller/kubeconfig-rbac"
@@ -318,6 +319,13 @@ func setupWorkloadControllers(mgr ctrl.Manager, client ctrlruntimeclient.Client)
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller %s: %w", "CompiledFrontProxy", err)
+	}
+
+	if err := (&compiledvirtualworkspace.Reconciler{
+		Client: client,
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "CompiledVirtualWorkspace", err)
 	}
 
 	return nil

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -73,6 +73,7 @@ rules:
   - compiledfrontproxies/status
   - compiledrootshards/status
   - compiledshards/status
+  - compiledvirtualworkspaces/status
   verbs:
   - get
   - patch

--- a/internal/controller/compiledvirtualworkspace/controller.go
+++ b/internal/controller/compiledvirtualworkspace/controller.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compiledvirtualworkspace
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	k8creconciling "k8c.io/reconciler/pkg/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	"github.com/kcp-dev/kcp-operator/internal/resources/virtualworkspace"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+// requeueAfter is the retry delay when a mounted Secret or ConfigMap does not exist yet.
+const requeueAfter = 10 * time.Second
+
+// Reconciler reconciles a CompiledVirtualWorkspace object.
+type Reconciler struct {
+	ctrlruntimeclient.Client
+	Scheme *runtime.Scheme
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("compiledvirtualworkspace").
+		For(&deployv1alpha1.CompiledVirtualWorkspace{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Complete(r)
+}
+
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledvirtualworkspaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups=deploy.operator.kcp.io,resources=compiledvirtualworkspaces/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=secrets;configmaps,verbs=get;list;watch
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.V(4).Info("Reconciling")
+
+	var compiled deployv1alpha1.CompiledVirtualWorkspace
+	if err := r.Get(ctx, req.NamespacedName, &compiled); err != nil {
+		return ctrl.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	if compiled.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	result, recErr := r.reconcile(ctx, &compiled)
+	statusErr := r.reconcileStatus(ctx, &compiled)
+
+	return result, kerrors.NewAggregate([]error{recErr, statusErr})
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, compiled *deployv1alpha1.CompiledVirtualWorkspace) (ctrl.Result, error) {
+	var (
+		errs    []error
+		requeue bool
+	)
+
+	vw := &operatorv1alpha1.VirtualWorkspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        compiled.Name,
+			Namespace:   compiled.Namespace,
+			Labels:      compiled.Labels,
+			Annotations: compiled.Annotations,
+		},
+		Spec: compiled.Spec.VirtualWorkspace,
+	}
+
+	rootShard := &operatorv1alpha1.RootShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Spec.RootShard.Name,
+			Namespace: compiled.Namespace,
+		},
+		Spec: compiled.Spec.RootShard.Spec,
+	}
+
+	var shard *operatorv1alpha1.Shard
+	if compiled.Spec.Shard != nil {
+		shard = &operatorv1alpha1.Shard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      compiled.Spec.Shard.Name,
+				Namespace: compiled.Namespace,
+			},
+			Spec: compiled.Spec.Shard.Spec,
+		}
+	}
+
+	ownerRef := *metav1.NewControllerRef(compiled, deployv1alpha1.SchemeGroupVersion.WithKind("CompiledVirtualWorkspace"))
+	ownerRefWrapper := k8creconciling.OwnerRefWrapper(ownerRef)
+	revisionLabels := modifier.RelatedRevisionsLabels(ctx, r.Client)
+
+	if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{
+		virtualworkspace.DeploymentReconciler(vw, rootShard, shard),
+	}, compiled.Namespace, r.Client, ownerRefWrapper, revisionLabels); err != nil {
+		if errors.Is(err, modifier.ErrMountNotFound) {
+			requeue = true
+		} else {
+			errs = append(errs, err)
+		}
+	}
+
+	if err := k8creconciling.ReconcileServices(ctx, []k8creconciling.NamedServiceReconcilerFactory{
+		virtualworkspace.ServiceReconciler(vw),
+	}, compiled.Namespace, r.Client, ownerRefWrapper); err != nil {
+		errs = append(errs, err)
+	}
+
+	result := ctrl.Result{}
+	if requeue {
+		result.RequeueAfter = requeueAfter
+	}
+
+	return result, kerrors.NewAggregate(errs)
+}
+
+func (r *Reconciler) reconcileStatus(ctx context.Context, oldCompiled *deployv1alpha1.CompiledVirtualWorkspace) error {
+	compiled := oldCompiled.DeepCopy()
+
+	vw := &operatorv1alpha1.VirtualWorkspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Name,
+			Namespace: compiled.Namespace,
+		},
+	}
+
+	depKey := types.NamespacedName{Namespace: compiled.Namespace, Name: resources.GetVirtualWorkspaceDeploymentName(vw)}
+	cond, err := util.GetDeploymentAvailableCondition(ctx, r.Client, depKey)
+	if err != nil {
+		return err
+	}
+
+	cond.ObservedGeneration = compiled.Generation
+	compiled.Status.Conditions = util.UpdateCondition(compiled.Status.Conditions, cond)
+
+	if !equality.Semantic.DeepEqual(oldCompiled.Status, compiled.Status) {
+		return r.Status().Patch(ctx, compiled, ctrlruntimeclient.MergeFrom(oldCompiled))
+	}
+
+	return nil
+}

--- a/internal/controller/compiledvirtualworkspace/controller_test.go
+++ b/internal/controller/compiledvirtualworkspace/controller_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compiledvirtualworkspace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kcp-dev/kcp-operator/internal/controller/util"
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	"github.com/kcp-dev/kcp-operator/internal/resources/virtualworkspace"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
+)
+
+func TestReconciling(t *testing.T) {
+	const namespace = "compiled-virtualworkspace-tests"
+
+	compiled := &deployv1alpha1.CompiledVirtualWorkspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "confy",
+			Namespace: namespace,
+		},
+		Spec: deployv1alpha1.CompiledVirtualWorkspaceSpec{
+			VirtualWorkspace: operatorv1alpha1.VirtualWorkspaceSpec{
+				External: operatorv1alpha1.ExternalConfig{
+					Hostname: "example.com",
+					Port:     6443,
+				},
+			},
+			RootShard: deployv1alpha1.NamedRootShardSpec{
+				Name: "rooty",
+				Spec: operatorv1alpha1.RootShardSpec{
+					External: operatorv1alpha1.ExternalConfig{
+						Hostname: "example.kcp.io",
+						Port:     6443,
+					},
+					CommonShardSpec: operatorv1alpha1.CommonShardSpec{
+						Etcd: operatorv1alpha1.EtcdConfig{
+							Endpoints: []string{"https://localhost:2379"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	vw := &operatorv1alpha1.VirtualWorkspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Name,
+			Namespace: compiled.Namespace,
+		},
+	}
+
+	rootShard := &operatorv1alpha1.RootShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      compiled.Spec.RootShard.Name,
+			Namespace: compiled.Namespace,
+		},
+	}
+
+	// Secrets mounted into the deployment must exist for the revision-labels modifier.
+	var mountedSecretNames []string
+	for _, ca := range []operatorv1alpha1.CA{
+		operatorv1alpha1.RootCA,
+		operatorv1alpha1.ServerCA,
+		operatorv1alpha1.RequestHeaderClientCA,
+		operatorv1alpha1.ClientCA,
+	} {
+		mountedSecretNames = append(mountedSecretNames, resources.GetRootShardCAName(rootShard, ca))
+	}
+	for _, cert := range []operatorv1alpha1.Certificate{
+		operatorv1alpha1.ServerCertificate,
+		operatorv1alpha1.ClientCertificate,
+	} {
+		mountedSecretNames = append(mountedSecretNames, resources.GetVirtualWorkspaceCertificateName(vw, cert))
+	}
+	mountedSecretNames = append(mountedSecretNames, resources.GetRootShardKubeconfigSecret(rootShard, operatorv1alpha1.LogicalClusterAdminCertificate))
+
+	objects := []ctrlruntimeclient.Object{compiled}
+	for _, name := range mountedSecretNames {
+		objects = append(objects, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		})
+	}
+
+	scheme := util.GetTestScheme()
+
+	client := ctrlruntimefakeclient.
+		NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(compiled).
+		Build()
+
+	ctx := context.Background()
+
+	controllerReconciler := &Reconciler{
+		Client: client,
+		Scheme: client.Scheme(),
+	}
+
+	_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(compiled),
+	})
+	require.NoError(t, err)
+
+	deployment := &appsv1.Deployment{}
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKey{
+		Name:      resources.GetVirtualWorkspaceDeploymentName(vw),
+		Namespace: namespace,
+	}, deployment)
+	require.NoError(t, err)
+	require.Len(t, deployment.OwnerReferences, 1)
+	require.Equal(t, "CompiledVirtualWorkspace", deployment.OwnerReferences[0].Kind)
+	require.Equal(t, compiled.Name, deployment.OwnerReferences[0].Name)
+
+	service := &corev1.Service{}
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKey{
+		Name:      virtualworkspace.GetVirtualWorkspaceServiceName(vw),
+		Namespace: namespace,
+	}, service)
+	require.NoError(t, err)
+	require.Len(t, service.OwnerReferences, 1)
+	require.Equal(t, "CompiledVirtualWorkspace", service.OwnerReferences[0].Kind)
+	require.Equal(t, compiled.Name, service.OwnerReferences[0].Name)
+
+	updated := &deployv1alpha1.CompiledVirtualWorkspace{}
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(compiled), updated)
+	require.NoError(t, err)
+
+	availableCond := apimeta.FindStatusCondition(updated.Status.Conditions, string(operatorv1alpha1.ConditionTypeAvailable))
+	require.NotNil(t, availableCond)
+	require.Equal(t, metav1.ConditionFalse, availableCond.Status)
+}

--- a/internal/controller/virtualworkspace/controller.go
+++ b/internal/controller/virtualworkspace/controller.go
@@ -26,7 +26,6 @@ import (
 	"k8c.io/reconciler/pkg/equality"
 	k8creconciling "k8c.io/reconciler/pkg/reconciling"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,6 +43,7 @@ import (
 	"github.com/kcp-dev/kcp-operator/internal/reconciling/modifier"
 	"github.com/kcp-dev/kcp-operator/internal/resources"
 	"github.com/kcp-dev/kcp-operator/internal/resources/virtualworkspace"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -61,10 +61,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&operatorv1alpha1.RootShard{}, handler.EnqueueRequestsFromMapFunc(r.mapRootShardToVirtualWorkspaces)).
 		Watches(&operatorv1alpha1.Shard{}, handler.EnqueueRequestsFromMapFunc(r.mapShardToVirtualWorkspaces)).
 		Watches(&certmanagerv1.Issuer{}, handler.EnqueueRequestsFromMapFunc(r.mapIssuerToVirtualWorkspaces)).
+		Owns(&deployv1alpha1.CompiledVirtualWorkspace{}).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.Service{}).
 		Owns(&certmanagerv1.Certificate{}).
-		Owns(&appsv1.Deployment{}).
 		Complete(r)
 }
 
@@ -196,7 +196,6 @@ func (r *Reconciler) reconcile(ctx context.Context, vw *operatorv1alpha1.Virtual
 	})
 
 	ownerRefWrapper := k8creconciling.OwnerRefWrapper(*metav1.NewControllerRef(vw, operatorv1alpha1.SchemeGroupVersion.WithKind("VirtualWorkspace")))
-	revisionLabels := modifier.RelatedRevisionsLabels(ctx, r.Client)
 
 	var certs []*certmanagerv1.Certificate
 	if err := reconciling.ReconcileCertificates(ctx, []reconciling.NamedCertificateReconcilerFactory{
@@ -225,34 +224,15 @@ func (r *Reconciler) reconcile(ctx context.Context, vw *operatorv1alpha1.Virtual
 		return conditions, err
 	}
 
-	if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{
-		virtualworkspace.DeploymentReconciler(vw, rootShard, shard),
-	}, vw.Namespace, r.Client, ownerRefWrapper, revisionLabels); err != nil {
-		// Swallow these errors and instead rely on us watching Secrets and re-reconciling whenever they change.
-		if errors.Is(err, modifier.ErrMountNotFound) {
-			err = nil
-		}
-
-		return conditions, err
-	}
-
-	if err := k8creconciling.ReconcileServices(ctx, []k8creconciling.NamedServiceReconcilerFactory{
-		virtualworkspace.ServiceReconciler(vw),
-	}, vw.Namespace, r.Client, ownerRefWrapper); err != nil {
-		return conditions, err
-	}
-
 	return conditions, nil
 }
 
 func (r *Reconciler) reconcileStatus(ctx context.Context, oldVW *operatorv1alpha1.VirtualWorkspace, vw *operatorv1alpha1.VirtualWorkspace, conditions []metav1.Condition) error {
-	// Check deployment status
-	depKey := types.NamespacedName{Namespace: vw.Namespace, Name: resources.GetVirtualWorkspaceDeploymentName(vw)}
-	cond, err := util.GetDeploymentAvailableCondition(ctx, r.Client, depKey)
-	if err != nil {
+	compiled := &deployv1alpha1.CompiledVirtualWorkspace{}
+	if err := r.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(vw), compiled); ctrlruntimeclient.IgnoreNotFound(err) != nil {
 		return err
 	}
-	conditions = append(conditions, cond)
+	conditions = append(conditions, util.GetCompiledAvailableCondition(compiled.Status.Conditions, fmt.Sprintf("CompiledVirtualWorkspace %s", vw.Name)))
 
 	for _, condition := range conditions {
 		condition.ObservedGeneration = vw.Generation


### PR DESCRIPTION
This PR is part of a stacked PR that splits kcp-operator's functionality
into two controller groups, `config` and `workload` and adds an
intermediate resource group deploy.operator.kcp.io. The config
controller group prepares and compiles resources into resources of the
group deploy.operator.kcp.io.

The `workload` then realizes the compiled resource into workload
resources (`Deployment` and `Service`).

```release-note
NONE
```

/kind feature

