### PR TITLE
Add config/workload e2e topologies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,16 @@ test-e2e: build ## Run e2e tests using existing cluster, bootstrap prerequisites
 
 # Creates a kind cluster and runs the e2e tests in them. The kind cluster is destroyed after the tests.
 # Example: USE_EXISTING_CLUSTER=true NO_TEARDOWN=true make test-e2e WHAT=./test/e2e/shards TEST_ARGS="-timeout 2h -v -run TestShardBundleAnnotation -count=1"
-.PHONY: test-e2e-with-kind  # Run the e2e tests against a temporary kind cluster.
-test-e2e-with-kind: ## Run e2e tests in temporary kind cluster. Use WHAT= to specify test path.
-	@WHAT=$(WHAT) hack/run-e2e-tests.sh
+.PHONY: test-e2e-with-kind  # Run the e2e tests in both topologies against temporary kind clusters.
+test-e2e-with-kind: test-e2e-with-kind-config-workload test-e2e-with-kind-single ## Run e2e tests in temporary kind clusters, both topologies.
+
+.PHONY: test-e2e-with-kind-single
+test-e2e-with-kind-single: ## Run e2e tests in a temporary single-topology kind cluster. Use WHAT= to specify test path.
+	@E2E_TOPOLOGY=single WHAT=$(WHAT) hack/run-e2e-tests.sh
+
+.PHONY: test-e2e-with-kind-config-workload
+test-e2e-with-kind-config-workload: ## Run e2e tests in temporary config-workload-topology kind clusters. Use WHAT= to specify test path.
+	@E2E_TOPOLOGY=config-workload WHAT=$(WHAT) hack/run-e2e-tests.sh
 
 GOLANGCI_LINT = $(UGET_DIRECTORY)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 

--- a/hack/ci/run-e2e-tests.sh
+++ b/hack/ci/run-e2e-tests.sh
@@ -76,33 +76,66 @@ export IMAGE_TAG=local
 echo "Building container images..."
 ARCHITECTURES=arm64 DRY_RUN=yes ./hack/ci/build-image.sh
 
-# create a local kind cluster
-KIND_CLUSTER_NAME=e2e
+# create the local kind cluster(s)
+export E2E_TOPOLOGY="${E2E_TOPOLOGY:-config-workload}"
+
+case "$E2E_TOPOLOGY" in
+  single)
+    # a single cluster runs both controller groups
+    CONFIG_CLUSTER_NAME=e2e
+    WORKLOAD_CLUSTER_NAME=""
+    ;;
+  config-workload)
+    # a config cluster runs the config controller group, a workload cluster the workload group
+    CONFIG_CLUSTER_NAME=e2e-config
+    WORKLOAD_CLUSTER_NAME=e2e-workload
+    ;;
+  *)
+    echo "ERROR: E2E_TOPOLOGY must be 'single' or 'config-workload', got '$E2E_TOPOLOGY'"
+    exit 1
+    ;;
+esac
 
 echo "Preloading the kindest/node image..."
 docker load --input /kindest.tar
 
 export KUBECONFIG=$(mktemp)
-echo "Creating kind cluster $KIND_CLUSTER_NAME..."
-create_kind_cluster "$KIND_CLUSTER_NAME" kindest/node:v1.32.2
+echo "Creating kind cluster $CONFIG_CLUSTER_NAME..."
+create_kind_cluster "$CONFIG_CLUSTER_NAME" kindest/node:v1.32.2
 chmod 600 "$KUBECONFIG"
+
+if [[ -n "$WORKLOAD_CLUSTER_NAME" ]]; then
+  export WORKLOAD_KUBECONFIG=$(mktemp)
+  echo "Creating kind cluster $WORKLOAD_CLUSTER_NAME..."
+  KUBECONFIG="$WORKLOAD_KUBECONFIG" create_kind_cluster "$WORKLOAD_CLUSTER_NAME" kindest/node:v1.32.2
+  chmod 600 "$WORKLOAD_KUBECONFIG"
+else
+  export WORKLOAD_KUBECONFIG="$KUBECONFIG"
+fi
 
 # preload the custom kcp image, if requested
 if [[ -n "$PRELOAD_IMAGE" ]]; then
-  echo "Preloading kcp image $PRELOAD_IMAGE into kind cluster..."
-  retry_linear 1 5 kind load docker-image "$PRELOAD_IMAGE" --name "$KIND_CLUSTER_NAME"
+  echo "Preloading kcp image $PRELOAD_IMAGE into kind clusters..."
+  retry_linear 1 5 kind load docker-image "$PRELOAD_IMAGE" --name "$CONFIG_CLUSTER_NAME"
+  if [[ -n "$WORKLOAD_CLUSTER_NAME" ]]; then
+    retry_linear 1 5 kind load docker-image "$PRELOAD_IMAGE" --name "$WORKLOAD_CLUSTER_NAME"
+  fi
 fi
 
-# apply kernel limits job first and wait for completion
+# apply kernel limits job on the workload cluster (where the kcp pods run)
+# first and wait for completion
 echo "Applying kernel limits job…"
 KUBECTL="$(UGET_PRINT_PATH=absolute make --no-print-directory install-kubectl)"
-"$KUBECTL" apply --filename hack/ci/kernel.yaml
-"$KUBECTL" wait --for=condition=Complete job/kernel-limits --timeout=300s
+KUBECONFIG="$WORKLOAD_KUBECONFIG" "$KUBECTL" apply --filename hack/ci/kernel.yaml
+KUBECONFIG="$WORKLOAD_KUBECONFIG" "$KUBECTL" wait --for=condition=Complete job/kernel-limits --timeout=300s
 echo "Kernel limits job completed."
 
 # store logs as artifacts (optional; protokol may not be available)
 if PROTOKOL="$(UGET_PRINT_PATH=absolute make --no-print-directory install-protokol 2>/dev/null)"; then
   "$PROTOKOL" --output "$ARTIFACTS/logs" --namespace 'kcp-*' --namespace 'e2e-*' >/dev/null 2>&1 &
+  if [[ -n "$WORKLOAD_CLUSTER_NAME" ]]; then
+    KUBECONFIG="$WORKLOAD_KUBECONFIG" "$PROTOKOL" --output "$ARTIFACTS/logs-workload" --namespace 'kcp-*' --namespace 'e2e-*' >/dev/null 2>&1 &
+  fi
 else
   echo "WARNING: failed to install protokol, logs will not be collected as artifacts"
 fi
@@ -110,19 +143,42 @@ fi
 # need Helm to setup etcd
 HELM="$(UGET_PRINT_PATH=absolute make --no-print-directory install-helm)"
 
-# load the operator image into the kind cluster
+# load the operator image into the kind clusters
 image="ghcr.io/kcp-dev/kcp-operator:$IMAGE_TAG"
 archive=operator.tar
 
 echo "Loading operator image into kind..."
 buildah manifest push --all "$image" "oci-archive:$archive:$image"
-kind load image-archive "$archive" --name "$KIND_CLUSTER_NAME"
+kind load image-archive "$archive" --name "$CONFIG_CLUSTER_NAME"
+if [[ -n "$WORKLOAD_CLUSTER_NAME" ]]; then
+  kind load image-archive "$archive" --name "$WORKLOAD_CLUSTER_NAME"
+fi
 
-# deploy the operator
-echo "Deploying operator..."
-"$KUBECTL" kustomize hack/ci/testdata | "$KUBECTL" apply --filename -
-"$KUBECTL" --namespace kcp-operator-system wait deployment kcp-operator-controller-manager --for condition=Available
-"$KUBECTL" --namespace kcp-operator-system wait pod --all --for condition=Ready
+if [[ "$E2E_TOPOLOGY" == config-workload ]]; then
+  # deploy the config cluster operator
+  echo "Deploying config operator..."
+  "$KUBECTL" kustomize hack/ci/testdata/config | "$KUBECTL" apply --server-side --filename -
+  "$KUBECTL" --namespace kcp-operator-system wait deployment kcp-operator-controller-manager --for condition=Available
+  "$KUBECTL" --namespace kcp-operator-system wait pod --all --for condition=Ready
+
+  # the workload cluster only needs the deploy.operator.kcp.io CRDs
+  echo "Deploying workload cluster operator..."
+  KUBECONFIG="$WORKLOAD_KUBECONFIG" "$KUBECTL" apply --server-side --kustomize config/crd/deploy
+  "$KUBECTL" kustomize hack/ci/testdata/workload | KUBECONFIG="$WORKLOAD_KUBECONFIG" "$KUBECTL" apply --server-side --filename -
+  KUBECONFIG="$WORKLOAD_KUBECONFIG" "$KUBECTL" --namespace kcp-operator-system wait deployment kcp-operator-controller-manager --for condition=Available
+  KUBECONFIG="$WORKLOAD_KUBECONFIG" "$KUBECTL" --namespace kcp-operator-system wait pod --all --for condition=Ready
+
+  # the syncer plays the role of an external GitOps tool, copying compiled
+  # resources and secrets from the config to the workload cluster
+  echo "Starting e2e syncer..."
+  go build -o "$ARTIFACTS/e2e-syncer" ./test/syncer
+  "$ARTIFACTS/e2e-syncer" --config-kubeconfig "$KUBECONFIG" --workload-kubeconfig "$WORKLOAD_KUBECONFIG" >"$ARTIFACTS/syncer.log" 2>&1 &
+else
+  echo "Deploying operator..."
+  "$KUBECTL" kustomize hack/ci/testdata/single | "$KUBECTL" apply --server-side --filename -
+  "$KUBECTL" --namespace kcp-operator-system wait deployment kcp-operator-controller-manager --for condition=Available
+  "$KUBECTL" --namespace kcp-operator-system wait pod --all --for condition=Ready
+fi
 
 # deploying cert-manager
 echo "Deploying cert-manager..."

--- a/hack/ci/testdata/config/kustomization.yaml
+++ b/hack/ci/testdata/config/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../../config/default
+  - ../../../../config/default
 images:
   - name: ghcr.io/kcp-dev/kcp-operator
     newTag: local
@@ -10,6 +10,9 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --feature-gates=ConfigurationBundle=true
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --enabled-controller-groups=config
     target:
       kind: Deployment
       name: controller-manager

--- a/hack/ci/testdata/single/kustomization.yaml
+++ b/hack/ci/testdata/single/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../config/default
+images:
+  - name: ghcr.io/kcp-dev/kcp-operator
+    newTag: local
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --feature-gates=ConfigurationBundle=true
+    target:
+      kind: Deployment
+      name: controller-manager
+      namespace: kcp-operator-system

--- a/hack/ci/testdata/workload/kustomization.yaml
+++ b/hack/ci/testdata/workload/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kcp-operator-system
+namePrefix: kcp-operator-
+resources:
+  - ../../../../config/rbac
+  - ../../../../config/manager
+images:
+  - name: ghcr.io/kcp-dev/kcp-operator
+    newTag: local
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --enabled-controller-groups=workload
+    target:
+      kind: Deployment
+      name: controller-manager

--- a/hack/run-e2e-tests.sh
+++ b/hack/run-e2e-tests.sh
@@ -20,34 +20,70 @@ cd $(dirname $0)/..
 source hack/lib.sh
 
 export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-e2e}"
-DATA_DIR=".e2e-$KIND_CLUSTER_NAME"
+export E2E_TOPOLOGY="${E2E_TOPOLOGY:-config-workload}"
+
+case "$E2E_TOPOLOGY" in
+  single)
+    # a single cluster runs both controller groups
+    CONFIG_CLUSTER_NAME="$KIND_CLUSTER_NAME"
+    WORKLOAD_CLUSTER_NAME=""
+    ;;
+  config-workload)
+    # a config cluster runs the config controller group, a workload cluster the workload group
+    CONFIG_CLUSTER_NAME="$KIND_CLUSTER_NAME-config"
+    WORKLOAD_CLUSTER_NAME="$KIND_CLUSTER_NAME-workload"
+    ;;
+  *)
+    echo "ERROR: E2E_TOPOLOGY must be 'single' or 'config-workload', got '$E2E_TOPOLOGY'"
+    exit 1
+    ;;
+esac
+
+DATA_DIR=".e2e-$KIND_CLUSTER_NAME-$E2E_TOPOLOGY"
 OPERATOR_PID=0
 PROTOKOL_PID=0
+WORKLOAD_PROTOKOL_PID=0
+SYNCER_PID=0
 NO_TEARDOWN=${NO_TEARDOWN:-false}
 USE_EXISTING_CLUSTER=${USE_EXISTING_CLUSTER:-false}
 
 mkdir -p "$DATA_DIR"
-rm -rf "$DATA_DIR/kind-logs"
+rm -rf "$DATA_DIR/kind-logs" "$DATA_DIR/kind-logs-workload"
 echo "Logs are stored in $DATA_DIR/."
 DATA_DIR="$(realpath "$DATA_DIR")"
 
 # create a local kind cluster or use existing one
 if $USE_EXISTING_CLUSTER; then
-  echo "Using existing cluster (USE_EXISTING_CLUSTER=true)..."
+  echo "Using existing clusters (USE_EXISTING_CLUSTER=true)..."
   if [[ -z "${KUBECONFIG:-}" ]]; then
     echo "ERROR: KUBECONFIG must be set when USE_EXISTING_CLUSTER=true"
     exit 1
   fi
-  # Convert to absolute path if relative
+  if [[ "$E2E_TOPOLOGY" == config-workload ]] && [[ -z "${WORKLOAD_KUBECONFIG:-}" ]]; then
+    echo "ERROR: WORKLOAD_KUBECONFIG must be set when USE_EXISTING_CLUSTER=true and E2E_TOPOLOGY=config-workload"
+    exit 1
+  fi
+  # Convert to absolute paths if relative
   export KUBECONFIG="$(realpath "$KUBECONFIG")"
-  export WORKLOAD_KUBECONFIG="$(realpath "$KUBECONFIG")"
+  export WORKLOAD_KUBECONFIG="$(realpath "${WORKLOAD_KUBECONFIG:-$KUBECONFIG}")"
   echo "Using KUBECONFIG: $KUBECONFIG"
+  echo "Using WORKLOAD_KUBECONFIG: $WORKLOAD_KUBECONFIG"
+  CONFIG_CLUSTER_NAME="$KIND_CLUSTER_NAME"
+  WORKLOAD_CLUSTER_NAME=""
 else
-  export KUBECONFIG="$DATA_DIR/kind.kubeconfig"
-  export WORKLOAD_KUBECONFIG="$DATA_DIR/kind.kubeconfig"
-  echo "Creating kind cluster $KIND_CLUSTER_NAME (set \$USE_EXISTING_CLUSTER to true to use your own)"
-  kind create cluster --name "$KIND_CLUSTER_NAME"
+  export KUBECONFIG="$DATA_DIR/kind-config.kubeconfig"
+  echo "Creating kind cluster $CONFIG_CLUSTER_NAME (set \$USE_EXISTING_CLUSTER to true to use your own)"
+  kind create cluster --name "$CONFIG_CLUSTER_NAME" --kubeconfig "$KUBECONFIG"
   chmod 600 "$KUBECONFIG"
+
+  if [[ -n "$WORKLOAD_CLUSTER_NAME" ]]; then
+    export WORKLOAD_KUBECONFIG="$DATA_DIR/kind-workload.kubeconfig"
+    echo "Creating kind cluster $WORKLOAD_CLUSTER_NAME"
+    kind create cluster --name "$WORKLOAD_CLUSTER_NAME" --kubeconfig "$WORKLOAD_KUBECONFIG"
+    chmod 600 "$WORKLOAD_KUBECONFIG"
+  else
+    export WORKLOAD_KUBECONFIG="$KUBECONFIG"
+  fi
 fi
 
 teardown_kind() {
@@ -57,9 +93,22 @@ teardown_kind() {
     # no wait because protokol ends quickly and wait would fail
   fi
 
+  if [[ $WORKLOAD_PROTOKOL_PID -gt 0 ]]; then
+    kill -TERM $WORKLOAD_PROTOKOL_PID
+  fi
+
+  if [[ $SYNCER_PID -gt 0 ]]; then
+    echo "Stopping e2e syncer..."
+    kill -TERM $SYNCER_PID
+  fi
+
   if ! $USE_EXISTING_CLUSTER; then
-    kind delete cluster --name "$KIND_CLUSTER_NAME"
+    kind delete cluster --name "$CONFIG_CLUSTER_NAME"
     rm "$KUBECONFIG"
+    if [[ -n "$WORKLOAD_CLUSTER_NAME" ]]; then
+      kind delete cluster --name "$WORKLOAD_CLUSTER_NAME"
+      rm "$WORKLOAD_KUBECONFIG"
+    fi
   fi
 }
 
@@ -110,7 +159,10 @@ if [ -n "${KCP_TAG:-}" ]; then
     docker pull "$ORIGINAL_IMAGE"
     docker tag "$ORIGINAL_IMAGE" "$PRELOAD_IMAGE"
 
-    retry_linear 1 5 kind load docker-image "$PRELOAD_IMAGE" --name "$KIND_CLUSTER_NAME"
+    retry_linear 1 5 kind load docker-image "$PRELOAD_IMAGE" --name "$CONFIG_CLUSTER_NAME"
+    if [[ -n "$WORKLOAD_CLUSTER_NAME" ]]; then
+      retry_linear 1 5 kind load docker-image "$PRELOAD_IMAGE" --name "$WORKLOAD_CLUSTER_NAME"
+    fi
   fi
 
   echo "kcp image tag: $KCP_TAG"
@@ -121,15 +173,23 @@ KUSTOMIZE="$(UGET_PRINT_PATH=absolute make --no-print-directory install-kustomiz
 HELM="$(UGET_PRINT_PATH=absolute make --no-print-directory install-helm)"
 PROTOKOL="$(UGET_PRINT_PATH=absolute make --no-print-directory install-protokol)"
 
-# apply kernel limits job first and wait for completion
+# apply kernel limits job first and wait for completion (kcp pods run on the workload cluster)
 echo "Applying kernel limits job..."
-"$KUBECTL" apply --filename hack/ci/kernel.yaml
-"$KUBECTL" wait --for=condition=Complete job/kernel-limits --timeout=300s
+KUBECONFIG="$WORKLOAD_KUBECONFIG" "$KUBECTL" apply --filename hack/ci/kernel.yaml
+KUBECONFIG="$WORKLOAD_KUBECONFIG" "$KUBECTL" wait --for=condition=Complete job/kernel-limits --timeout=300s
 echo "Kernel limits job completed."
 
 # deploying operator CRDs
 echo "Deploying operator CRDs..."
 "$KUBECTL" apply --server-side --kustomize config/crd
+
+if [[ "$E2E_TOPOLOGY" == config-workload ]]; then
+  echo "Deploying compiled resource CRDs on the workload cluster..."
+  KUBECONFIG="$WORKLOAD_KUBECONFIG" "$KUBECTL" apply --server-side --kustomize config/crd/deploy
+else
+  echo "Deploying compiled resource CRDs..."
+  "$KUBECTL" apply --server-side --kustomize config/crd/deploy
+fi
 
 # deploying cert-manager
 echo "Deploying cert-manager..."
@@ -151,13 +211,35 @@ echo "Deploying cert-manager..."
 # build operator image it into kind
 echo "Building and loading kcp-operator..."
 export IMG="ghcr.io/kcp-dev/kcp-operator:local"
-make --no-print-directory docker-build kind-load
+make --no-print-directory docker-build
+KIND_CLUSTER_NAME="$CONFIG_CLUSTER_NAME" make --no-print-directory kind-load
+if [[ -n "$WORKLOAD_CLUSTER_NAME" ]]; then
+  KIND_CLUSTER_NAME="$WORKLOAD_CLUSTER_NAME" make --no-print-directory kind-load
+fi
 
-echo "Deploying kcp-operator..."
-"$KUSTOMIZE" build hack/ci/testdata | "$KUBECTL" apply --filename -
+if [[ "$E2E_TOPOLOGY" == config-workload ]]; then
+  echo "Deploying config kcp-operator..."
+  "$KUSTOMIZE" build hack/ci/testdata/config | "$KUBECTL" apply --server-side --filename -
+
+  echo "Deploying workload-only kcp-operator..."
+  "$KUSTOMIZE" build hack/ci/testdata/workload | KUBECONFIG="$WORKLOAD_KUBECONFIG" "$KUBECTL" apply --server-side --filename -
+
+  echo "Building and starting e2e syncer..."
+  go build -o "$DATA_DIR/e2e-syncer" ./test/syncer
+  "$DATA_DIR/e2e-syncer" --config-kubeconfig "$KUBECONFIG" --workload-kubeconfig "$WORKLOAD_KUBECONFIG" >"$DATA_DIR/syncer.log" 2>&1 &
+  SYNCER_PID=$!
+else
+  echo "Deploying kcp-operator..."
+  "$KUSTOMIZE" build hack/ci/testdata/single | "$KUBECTL" apply --server-side --filename -
+fi
 
 "$PROTOKOL" --namespace 'e2e-*' --namespace kcp-operator-system --output "$DATA_DIR/kind-logs" 2>/dev/null &
 PROTOKOL_PID=$!
+
+if [[ "$E2E_TOPOLOGY" == config-workload ]]; then
+  KUBECONFIG="$WORKLOAD_KUBECONFIG" "$PROTOKOL" --namespace 'e2e-*' --namespace kcp-operator-system --output "$DATA_DIR/kind-logs-workload" 2>/dev/null &
+  WORKLOAD_PROTOKOL_PID=$!
+fi
 
 echo "Running e2e tests..."
 

--- a/hack/run-e2e-tests.sh
+++ b/hack/run-e2e-tests.sh
@@ -40,9 +40,11 @@ if $USE_EXISTING_CLUSTER; then
   fi
   # Convert to absolute path if relative
   export KUBECONFIG="$(realpath "$KUBECONFIG")"
+  export WORKLOAD_KUBECONFIG="$(realpath "$KUBECONFIG")"
   echo "Using KUBECONFIG: $KUBECONFIG"
 else
   export KUBECONFIG="$DATA_DIR/kind.kubeconfig"
+  export WORKLOAD_KUBECONFIG="$DATA_DIR/kind.kubeconfig"
   echo "Creating kind cluster $KIND_CLUSTER_NAME (set \$USE_EXISTING_CLUSTER to true to use your own)"
   kind create cluster --name "$KIND_CLUSTER_NAME"
   chmod 600 "$KUBECONFIG"

--- a/test/e2e/cacheserver/cacheserver_test.go
+++ b/test/e2e/cacheserver/cacheserver_test.go
@@ -40,17 +40,18 @@ import (
 func TestCacheWithRootShard(t *testing.T) {
 	ctrlruntime.SetLogger(logr.Discard())
 
-	client := utils.GetKubeClient(t)
+	configClient := utils.GetConfigKubeClient(t)
+	workloadClient := utils.GetWorkloadKubeClient(t)
 	ctx := context.Background()
 
 	// create namespace
-	namespace := utils.CreateSelfDestructingNamespace(t, ctx, client, "cache-rootshard")
+	namespace := utils.CreateSelfDestructingNamespace(t, ctx, configClient, "cache-rootshard")
 
 	// deploy the cache server
-	cacheServer := utils.DeployCacheServer(ctx, t, client, namespace.Name)
+	cacheServer := utils.DeployCacheServer(ctx, t, configClient, workloadClient, namespace.Name)
 
 	// deploy a root shard that uses our cache
-	rootShard := utils.DeployRootShard(ctx, t, client, namespace.Name, "", func(rs *operatorv1alpha1.RootShard) {
+	rootShard := utils.DeployRootShard(ctx, t, configClient, workloadClient, namespace.Name, "", func(rs *operatorv1alpha1.RootShard) {
 		rs.Spec.Cache.Reference = &corev1.LocalObjectReference{
 			Name: cacheServer.Name,
 		}
@@ -78,13 +79,13 @@ func TestCacheWithRootShard(t *testing.T) {
 	}
 
 	t.Log("Creating kubeconfig for RootShard...")
-	if err := client.Create(ctx, &rsConfig); err != nil {
+	if err := configClient.Create(ctx, &rsConfig); err != nil {
 		t.Fatal(err)
 	}
-	utils.WaitForObject(t, ctx, client, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
+	utils.WaitForObject(t, ctx, configClient, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
 
 	t.Log("Connecting to RootShard...")
-	rootShardClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace.Name, rsConfig.Name, logicalcluster.NewPath("root"))
+	rootShardClient := utils.ConnectWithKubeconfig(t, ctx, configClient, namespace.Name, rsConfig.Name, logicalcluster.NewPath("root"))
 
 	// proof of life: list something every logicalcluster in kcp has
 	t.Log("Should be able to list Secrets.")
@@ -102,17 +103,18 @@ func TestCacheWithExternalEtcdAndRootShard(t *testing.T) {
 
 	ctrlruntime.SetLogger(logr.Discard())
 
-	client := utils.GetKubeClient(t)
+	configClient := utils.GetConfigKubeClient(t)
+	workloadClient := utils.GetWorkloadKubeClient(t)
 	ctx := context.Background()
 
 	// create namespace
-	namespace := utils.CreateSelfDestructingNamespace(t, ctx, client, "cache-with-etcd-rootshard")
+	namespace := utils.CreateSelfDestructingNamespace(t, ctx, configClient, "cache-with-etcd-rootshard")
 
 	// deploy the cache server
-	cacheServer := utils.DeployCacheServerWithExternalEtcd(ctx, t, client, namespace.Name, 2)
+	cacheServer := utils.DeployCacheServerWithExternalEtcd(ctx, t, configClient, workloadClient, namespace.Name, 2)
 
 	// deploy a root shard that uses our cache
-	rootShard := utils.DeployRootShard(ctx, t, client, namespace.Name, "", func(rs *operatorv1alpha1.RootShard) {
+	rootShard := utils.DeployRootShard(ctx, t, configClient, workloadClient, namespace.Name, "", func(rs *operatorv1alpha1.RootShard) {
 		rs.Spec.Cache.Reference = &corev1.LocalObjectReference{
 			Name: cacheServer.Name,
 		}
@@ -140,13 +142,13 @@ func TestCacheWithExternalEtcdAndRootShard(t *testing.T) {
 	}
 
 	t.Log("Creating kubeconfig for RootShard...")
-	if err := client.Create(ctx, &rsConfig); err != nil {
+	if err := configClient.Create(ctx, &rsConfig); err != nil {
 		t.Fatal(err)
 	}
-	utils.WaitForObject(t, ctx, client, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
+	utils.WaitForObject(t, ctx, configClient, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
 
 	t.Log("Connecting to RootShard...")
-	rootShardClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace.Name, rsConfig.Name, logicalcluster.NewPath("root"))
+	rootShardClient := utils.ConnectWithKubeconfig(t, ctx, configClient, namespace.Name, rsConfig.Name, logicalcluster.NewPath("root"))
 
 	// proof of life: list something every logicalcluster in kcp has
 	t.Log("Should be able to list Secrets.")
@@ -159,17 +161,18 @@ func TestCacheWithExternalEtcdAndRootShard(t *testing.T) {
 func TestCacheWithMultipleExplicitShards(t *testing.T) {
 	ctrlruntime.SetLogger(logr.Discard())
 
-	client := utils.GetKubeClient(t)
+	configClient := utils.GetConfigKubeClient(t)
+	workloadClient := utils.GetWorkloadKubeClient(t)
 	ctx := context.Background()
 
 	// create namespace
-	namespace := utils.CreateSelfDestructingNamespace(t, ctx, client, "cache-sharded-explicit")
+	namespace := utils.CreateSelfDestructingNamespace(t, ctx, configClient, "cache-sharded-explicit")
 
 	// deploy the cache server
-	cacheServer := utils.DeployCacheServer(ctx, t, client, namespace.Name)
+	cacheServer := utils.DeployCacheServer(ctx, t, configClient, workloadClient, namespace.Name)
 
 	// deploy a root shard that uses our cache
-	rootShard := utils.DeployRootShard(ctx, t, client, namespace.Name, "", func(rs *operatorv1alpha1.RootShard) {
+	rootShard := utils.DeployRootShard(ctx, t, configClient, workloadClient, namespace.Name, "", func(rs *operatorv1alpha1.RootShard) {
 		rs.Spec.Cache.Reference = &corev1.LocalObjectReference{
 			Name: cacheServer.Name,
 		}
@@ -177,7 +180,7 @@ func TestCacheWithMultipleExplicitShards(t *testing.T) {
 
 	// deploy a 2nd shard incl. etcd
 	shardName := "aadvark"
-	utils.DeployShard(ctx, t, client, namespace.Name, shardName, rootShard.Name, func(s *operatorv1alpha1.Shard) {
+	utils.DeployShard(ctx, t, configClient, workloadClient, namespace.Name, shardName, rootShard.Name, func(s *operatorv1alpha1.Shard) {
 		s.Spec.Cache = &operatorv1alpha1.ShardCacheConfig{
 			Reference: &corev1.LocalObjectReference{
 				Name: cacheServer.Name,
@@ -207,13 +210,13 @@ func TestCacheWithMultipleExplicitShards(t *testing.T) {
 	}
 
 	t.Log("Creating kubeconfig for RootShard...")
-	if err := client.Create(ctx, &rsConfig); err != nil {
+	if err := configClient.Create(ctx, &rsConfig); err != nil {
 		t.Fatal(err)
 	}
-	utils.WaitForObject(t, ctx, client, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
+	utils.WaitForObject(t, ctx, configClient, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
 
 	t.Log("Connecting to RootShard...")
-	rootShardClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace.Name, rsConfig.Name, logicalcluster.NewPath("root"))
+	rootShardClient := utils.ConnectWithKubeconfig(t, ctx, configClient, namespace.Name, rsConfig.Name, logicalcluster.NewPath("root"))
 
 	// proof of life: list something every logicalcluster in kcp has
 	t.Log("Should be able to list Secrets.")
@@ -226,17 +229,18 @@ func TestCacheWithMultipleExplicitShards(t *testing.T) {
 func TestCacheWithMultipleShardsInheritingConfig(t *testing.T) {
 	ctrlruntime.SetLogger(logr.Discard())
 
-	client := utils.GetKubeClient(t)
+	configClient := utils.GetConfigKubeClient(t)
+	workloadClient := utils.GetWorkloadKubeClient(t)
 	ctx := context.Background()
 
 	// create namespace
-	namespace := utils.CreateSelfDestructingNamespace(t, ctx, client, "cache-sharded-inherit")
+	namespace := utils.CreateSelfDestructingNamespace(t, ctx, configClient, "cache-sharded-inherit")
 
 	// deploy the cache server
-	cacheServer := utils.DeployCacheServer(ctx, t, client, namespace.Name)
+	cacheServer := utils.DeployCacheServer(ctx, t, configClient, workloadClient, namespace.Name)
 
 	// deploy a root shard that uses our cache
-	rootShard := utils.DeployRootShard(ctx, t, client, namespace.Name, "", func(rs *operatorv1alpha1.RootShard) {
+	rootShard := utils.DeployRootShard(ctx, t, configClient, workloadClient, namespace.Name, "", func(rs *operatorv1alpha1.RootShard) {
 		rs.Spec.Cache.Reference = &corev1.LocalObjectReference{
 			Name: cacheServer.Name,
 		}
@@ -245,7 +249,7 @@ func TestCacheWithMultipleShardsInheritingConfig(t *testing.T) {
 	// deploy a 2nd shard incl. etcd, but WITHOUT an explicit cache config
 	// (it should inherit the cache config from the root shard)
 	shardName := "aadvark"
-	utils.DeployShard(ctx, t, client, namespace.Name, shardName, rootShard.Name)
+	utils.DeployShard(ctx, t, configClient, workloadClient, namespace.Name, shardName, rootShard.Name)
 
 	// create a kubeconfig to access the root shard
 	configSecretName := fmt.Sprintf("%s-shard-kubeconfig", rootShard.Name)
@@ -269,13 +273,13 @@ func TestCacheWithMultipleShardsInheritingConfig(t *testing.T) {
 	}
 
 	t.Log("Creating kubeconfig for RootShard...")
-	if err := client.Create(ctx, &rsConfig); err != nil {
+	if err := configClient.Create(ctx, &rsConfig); err != nil {
 		t.Fatal(err)
 	}
-	utils.WaitForObject(t, ctx, client, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
+	utils.WaitForObject(t, ctx, configClient, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
 
 	t.Log("Connecting to RootShard...")
-	rootShardClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace.Name, rsConfig.Name, logicalcluster.NewPath("root"))
+	rootShardClient := utils.ConnectWithKubeconfig(t, ctx, configClient, namespace.Name, rsConfig.Name, logicalcluster.NewPath("root"))
 
 	// proof of life: list something every logicalcluster in kcp has
 	t.Log("Should be able to list Secrets.")

--- a/test/e2e/frontproxies/frontproxies_test.go
+++ b/test/e2e/frontproxies/frontproxies_test.go
@@ -39,19 +39,20 @@ import (
 func TestCreateFrontProxy(t *testing.T) {
 	ctrlruntime.SetLogger(logr.Discard())
 
-	client := utils.GetKubeClient(t)
+	configClient := utils.GetConfigKubeClient(t)
+	workloadClient := utils.GetWorkloadKubeClient(t)
 	ctx := context.Background()
 
-	namespace := utils.CreateSelfDestructingNamespace(t, ctx, client, "create-frontproxy")
+	namespace := utils.CreateSelfDestructingNamespace(t, ctx, configClient, "create-frontproxy")
 
 	// externalHostname must match whatever DeployFrontProxy chooses as the name for the FrontProxy
 	externalHostname := fmt.Sprintf("front-proxy-front-proxy.%s.svc.cluster.local", namespace.Name)
 
 	// deploy rootshard
-	rootShard := utils.DeployRootShard(ctx, t, client, namespace.Name, externalHostname)
+	rootShard := utils.DeployRootShard(ctx, t, configClient, workloadClient, namespace.Name, externalHostname)
 
 	// deploy front-proxy
-	frontProxy := utils.DeployFrontProxy(ctx, t, client, namespace.Name, rootShard.Name, externalHostname)
+	frontProxy := utils.DeployFrontProxy(ctx, t, configClient, workloadClient, namespace.Name, rootShard.Name, externalHostname)
 
 	// create front-proxy kubeconfig
 	configSecretName := "kubeconfig-front-proxy-e2e"
@@ -74,14 +75,14 @@ func TestCreateFrontProxy(t *testing.T) {
 	}
 
 	t.Log("Creating kubeconfig for FrontProxy...")
-	if err := client.Create(ctx, &fpConfig); err != nil {
+	if err := configClient.Create(ctx, &fpConfig); err != nil {
 		t.Fatal(err)
 	}
-	utils.WaitForObject(t, ctx, client, &corev1.Secret{}, types.NamespacedName{Namespace: fpConfig.Namespace, Name: fpConfig.Spec.SecretRef.Name})
+	utils.WaitForObject(t, ctx, configClient, &corev1.Secret{}, types.NamespacedName{Namespace: fpConfig.Namespace, Name: fpConfig.Spec.SecretRef.Name})
 
 	// verify that we can use frontproxy kubeconfig to access rootshard workspaces
 	t.Log("Connecting to FrontProxy...")
-	kcpClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace.Name, fpConfig.Name, logicalcluster.None)
+	kcpClient := utils.ConnectWithKubeconfig(t, ctx, configClient, namespace.Name, fpConfig.Name, logicalcluster.None)
 	// proof of life: list something every logicalcluster in kcp has
 	t.Log("Should be able to list Secrets.")
 	secrets := &corev1.SecretList{}

--- a/test/e2e/kubeconfig-rbac/frontproxies_test.go
+++ b/test/e2e/kubeconfig-rbac/frontproxies_test.go
@@ -40,6 +40,11 @@ import (
 )
 
 func TestProvisionFrontProxyRBAC(t *testing.T) {
+	// TODO(ntnn): This needs some re-engineering. The RBAC controller
+	// uses the internal root proxy, but it isn't available in the
+	// config/workload topology.
+	utils.SkipUnlessTopology(t, utils.TopologySingle)
+
 	ctrlruntime.SetLogger(logr.Discard())
 
 	configClient := utils.GetConfigKubeClient(t)

--- a/test/e2e/kubeconfig-rbac/frontproxies_test.go
+++ b/test/e2e/kubeconfig-rbac/frontproxies_test.go
@@ -42,20 +42,21 @@ import (
 func TestProvisionFrontProxyRBAC(t *testing.T) {
 	ctrlruntime.SetLogger(logr.Discard())
 
-	client := utils.GetKubeClient(t)
+	configClient := utils.GetConfigKubeClient(t)
+	workloadClient := utils.GetWorkloadKubeClient(t)
 	ctx := context.Background()
 
 	rootCluster := logicalcluster.NewPath("root")
-	namespace := utils.CreateSelfDestructingNamespace(t, ctx, client, "provision-frontproxy-rbac")
+	namespace := utils.CreateSelfDestructingNamespace(t, ctx, configClient, "provision-frontproxy-rbac")
 
 	// externalHostname must match whatever DeployFrontProxy chooses as the name for the FrontProxy
 	externalHostname := fmt.Sprintf("front-proxy-front-proxy.%s.svc.cluster.local", namespace.Name)
 
 	// deploy rootshard
-	rootShard := utils.DeployRootShard(ctx, t, client, namespace.Name, externalHostname)
+	rootShard := utils.DeployRootShard(ctx, t, configClient, workloadClient, namespace.Name, externalHostname)
 
 	// deploy front-proxy
-	frontProxy := utils.DeployFrontProxy(ctx, t, client, namespace.Name, rootShard.Name, externalHostname)
+	frontProxy := utils.DeployFrontProxy(ctx, t, configClient, workloadClient, namespace.Name, rootShard.Name, externalHostname)
 
 	// create a dummy workspace where we later want to provision RBAC in
 	t.Log("Creating dummy workspace…")
@@ -71,14 +72,14 @@ func TestProvisionFrontProxyRBAC(t *testing.T) {
 	}
 
 	dummyCluster := rootCluster.Join(workspace.Name)
-	proxyClient := utils.ConnectWithRootShardProxy(t, ctx, client, &rootShard, rootCluster)
+	proxyClient := utils.ConnectWithRootShardProxy(t, ctx, configClient, &rootShard, rootCluster)
 	if err := proxyClient.Create(ctx, workspace); err != nil {
 		t.Fatalf("Failed to create workspace: %v", err)
 	}
 
 	// wait for workspace to be ready
 	t.Log("Waiting for workspace to be ready…")
-	dummyClient := utils.ConnectWithRootShardProxy(t, ctx, client, &rootShard, dummyCluster)
+	dummyClient := utils.ConnectWithRootShardProxy(t, ctx, configClient, &rootShard, dummyCluster)
 
 	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		return dummyClient.List(ctx, &corev1.SecretList{}) == nil, nil
@@ -145,13 +146,13 @@ func TestProvisionFrontProxyRBAC(t *testing.T) {
 			}
 
 			t.Log("Creating kubeconfig with no permissions attached…")
-			if err := client.Create(ctx, &fpConfig); err != nil {
+			if err := configClient.Create(ctx, &fpConfig); err != nil {
 				t.Fatal(err)
 			}
-			utils.WaitForObject(t, ctx, client, &corev1.Secret{}, types.NamespacedName{Namespace: fpConfig.Namespace, Name: fpConfig.Spec.SecretRef.Name})
+			utils.WaitForObject(t, ctx, configClient, &corev1.Secret{}, types.NamespacedName{Namespace: fpConfig.Namespace, Name: fpConfig.Spec.SecretRef.Name})
 
 			t.Log("Connecting to FrontProxy…")
-			kcpClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace.Name, fpConfig.Name, dummyCluster)
+			kcpClient := utils.ConnectWithKubeconfig(t, ctx, configClient, namespace.Name, fpConfig.Name, dummyCluster)
 
 			// This should not work yet.
 			t.Logf("Should not be able to list Secrets in %v.", dummyCluster)
@@ -160,14 +161,14 @@ func TestProvisionFrontProxyRBAC(t *testing.T) {
 			}
 
 			// Now we extend the Kubeconfig with additional permissions.
-			if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(&fpConfig), &fpConfig); err != nil {
+			if err := configClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(&fpConfig), &fpConfig); err != nil {
 				t.Fatal(err)
 			}
 
 			tc.applyRBAC(&fpConfig)
 
 			t.Log("Updating kubeconfig with permissions attached…")
-			if err := client.Update(ctx, &fpConfig); err != nil {
+			if err := configClient.Update(ctx, &fpConfig); err != nil {
 				t.Fatal(err)
 			}
 
@@ -181,13 +182,13 @@ func TestProvisionFrontProxyRBAC(t *testing.T) {
 
 			// And now we remove the permissions again.
 			t.Log("Updating kubeconfig to remove the attached permissions…")
-			if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(&fpConfig), &fpConfig); err != nil {
+			if err := configClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(&fpConfig), &fpConfig); err != nil {
 				t.Fatal(err)
 			}
 
 			tc.removeRBAC(&fpConfig)
 
-			if err := client.Update(ctx, &fpConfig); err != nil {
+			if err := configClient.Update(ctx, &fpConfig); err != nil {
 				t.Fatal(err)
 			}
 

--- a/test/e2e/rootshards/proxy_test.go
+++ b/test/e2e/rootshards/proxy_test.go
@@ -43,23 +43,24 @@ import (
 func TestRootShardProxy(t *testing.T) {
 	ctrlruntime.SetLogger(logr.Discard())
 
-	client := utils.GetKubeClient(t)
+	configClient := utils.GetConfigKubeClient(t)
+	workloadClient := utils.GetWorkloadKubeClient(t)
 	ctx := context.Background()
 
-	namespace := utils.CreateSelfDestructingNamespace(t, ctx, client, "rootshard-proxy")
+	namespace := utils.CreateSelfDestructingNamespace(t, ctx, configClient, "rootshard-proxy")
 
 	// externalHostname must match whatever DeployFrontProxy chooses as the name for the FrontProxy
 	externalHostname := fmt.Sprintf("front-proxy-front-proxy.%s.svc.cluster.local", namespace.Name)
 
 	// deploy a root shard incl. etcd
-	rootShard := utils.DeployRootShard(ctx, t, client, namespace.Name, externalHostname)
+	rootShard := utils.DeployRootShard(ctx, t, configClient, workloadClient, namespace.Name, externalHostname)
 
 	// deploy a 2nd shard incl. etcd
 	shardName := "aadvark"
-	utils.DeployShard(ctx, t, client, namespace.Name, shardName, rootShard.Name)
+	utils.DeployShard(ctx, t, configClient, workloadClient, namespace.Name, shardName, rootShard.Name)
 
 	// deploy front-proxy
-	utils.DeployFrontProxy(ctx, t, client, namespace.Name, rootShard.Name, externalHostname)
+	utils.DeployFrontProxy(ctx, t, configClient, workloadClient, namespace.Name, rootShard.Name, externalHostname)
 
 	configSecretName := "kubeconfig"
 
@@ -82,13 +83,13 @@ func TestRootShardProxy(t *testing.T) {
 	}
 
 	t.Log("Creating kubeconfig for RootShard...")
-	if err := client.Create(ctx, &rsConfig); err != nil {
+	if err := configClient.Create(ctx, &rsConfig); err != nil {
 		t.Fatal(err)
 	}
-	utils.WaitForObject(t, ctx, client, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
+	utils.WaitForObject(t, ctx, configClient, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
 
 	t.Log("Connecting to RootShard...")
-	rootShardClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace.Name, rsConfig.Name, logicalcluster.None)
+	rootShardClient := utils.ConnectWithKubeconfig(t, ctx, configClient, namespace.Name, rsConfig.Name, logicalcluster.None)
 
 	// wait until the 2nd shard has registered itself successfully at the root shard
 	shardKey := types.NamespacedName{Name: shardName}
@@ -131,7 +132,7 @@ func TestRootShardProxy(t *testing.T) {
 	}
 
 	// build a client through the proxy to the new workspace
-	proxyClient := utils.ConnectWithRootShardProxy(t, ctx, client, &rootShard, logicalcluster.NewPath("root").Join(workspace.Name))
+	proxyClient := utils.ConnectWithRootShardProxy(t, ctx, configClient, &rootShard, logicalcluster.NewPath("root").Join(workspace.Name))
 
 	// proof of life: list something every logicalcluster in kcp has
 	t.Log("Should be able to list Secrets in the new workspace.")

--- a/test/e2e/rootshards/rootshards_test.go
+++ b/test/e2e/rootshards/rootshards_test.go
@@ -38,11 +38,12 @@ import (
 func TestCreateRootShard(t *testing.T) {
 	ctrlruntime.SetLogger(logr.Discard())
 
-	client := utils.GetKubeClient(t)
+	configClient := utils.GetConfigKubeClient(t)
+	workloadClient := utils.GetWorkloadKubeClient(t)
 	ctx := context.Background()
 
-	namespace := utils.CreateSelfDestructingNamespace(t, ctx, client, "create-rootshard")
-	rootShard := utils.DeployRootShard(ctx, t, client, namespace.Name, "")
+	namespace := utils.CreateSelfDestructingNamespace(t, ctx, configClient, "create-rootshard")
+	rootShard := utils.DeployRootShard(ctx, t, configClient, workloadClient, namespace.Name, "")
 
 	configSecretName := "kubeconfig"
 
@@ -65,13 +66,13 @@ func TestCreateRootShard(t *testing.T) {
 	}
 
 	t.Log("Creating kubeconfig for RootShard...")
-	if err := client.Create(ctx, &rsConfig); err != nil {
+	if err := configClient.Create(ctx, &rsConfig); err != nil {
 		t.Fatal(err)
 	}
-	utils.WaitForObject(t, ctx, client, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
+	utils.WaitForObject(t, ctx, configClient, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
 
 	t.Log("Connecting to RootShard...")
-	kcpClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace.Name, rsConfig.Name, logicalcluster.None)
+	kcpClient := utils.ConnectWithKubeconfig(t, ctx, configClient, namespace.Name, rsConfig.Name, logicalcluster.None)
 
 	// proof of life: list something every logicalcluster in kcp has
 	t.Log("Should be able to list Secrets.")

--- a/test/e2e/shards/shards_test.go
+++ b/test/e2e/shards/shards_test.go
@@ -41,18 +41,19 @@ import (
 func TestCreateShard(t *testing.T) {
 	ctrlruntime.SetLogger(logr.Discard())
 
-	client := utils.GetKubeClient(t)
+	configClient := utils.GetConfigKubeClient(t)
+	workloadClient := utils.GetWorkloadKubeClient(t)
 	ctx := context.Background()
 
 	// create namespace
-	namespace := utils.CreateSelfDestructingNamespace(t, ctx, client, "create-shard")
+	namespace := utils.CreateSelfDestructingNamespace(t, ctx, configClient, "create-shard")
 
 	// deploy a root shard incl. etcd
-	rootShard := utils.DeployRootShard(ctx, t, client, namespace.Name, "")
+	rootShard := utils.DeployRootShard(ctx, t, configClient, workloadClient, namespace.Name, "")
 
 	// deploy a 2nd shard incl. etcd
 	shardName := "aadvark"
-	utils.DeployShard(ctx, t, client, namespace.Name, shardName, rootShard.Name)
+	utils.DeployShard(ctx, t, configClient, workloadClient, namespace.Name, shardName, rootShard.Name)
 
 	// create a kubeconfig to access the root shard
 	configSecretName := fmt.Sprintf("%s-shard-kubeconfig", rootShard.Name)
@@ -76,13 +77,13 @@ func TestCreateShard(t *testing.T) {
 	}
 
 	t.Log("Creating kubeconfig for RootShard...")
-	if err := client.Create(ctx, &rsConfig); err != nil {
+	if err := configClient.Create(ctx, &rsConfig); err != nil {
 		t.Fatal(err)
 	}
-	utils.WaitForObject(t, ctx, client, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
+	utils.WaitForObject(t, ctx, configClient, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
 
 	t.Log("Connecting to RootShard...")
-	rootShardClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace.Name, rsConfig.Name, logicalcluster.None)
+	rootShardClient := utils.ConnectWithKubeconfig(t, ctx, configClient, namespace.Name, rsConfig.Name, logicalcluster.None)
 
 	// wait until the 2nd shard has registered itself successfully at the root shard
 	shardKey := types.NamespacedName{Name: shardName}
@@ -111,13 +112,13 @@ func TestCreateShard(t *testing.T) {
 	}
 
 	t.Log("Creating kubeconfig for Shard...")
-	if err := client.Create(ctx, &shardConfig); err != nil {
+	if err := configClient.Create(ctx, &shardConfig); err != nil {
 		t.Fatal(err)
 	}
-	utils.WaitForObject(t, ctx, client, &corev1.Secret{}, types.NamespacedName{Namespace: shardConfig.Namespace, Name: shardConfig.Spec.SecretRef.Name})
+	utils.WaitForObject(t, ctx, configClient, &corev1.Secret{}, types.NamespacedName{Namespace: shardConfig.Namespace, Name: shardConfig.Spec.SecretRef.Name})
 
 	t.Log("Connecting to Shard...")
-	kcpClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace.Name, shardConfig.Name, logicalcluster.None)
+	kcpClient := utils.ConnectWithKubeconfig(t, ctx, configClient, namespace.Name, shardConfig.Name, logicalcluster.None)
 
 	// proof of life: list something every logicalcluster in kcp has
 	t.Log("Should be able to list Secrets.")
@@ -129,11 +130,11 @@ func TestCreateShard(t *testing.T) {
 	// Test cleanup: delete the operator's Shard CR and verify the kcp Shard object is cleaned up
 	t.Log("Deleting operator Shard CR...")
 	shard := &operatorv1alpha1.Shard{}
-	if err := client.Get(ctx, types.NamespacedName{Namespace: namespace.Name, Name: shardName}, shard); err != nil {
+	if err := configClient.Get(ctx, types.NamespacedName{Namespace: namespace.Name, Name: shardName}, shard); err != nil {
 		t.Fatalf("Failed to get Shard: %v", err)
 	}
 	t.Logf("Shard finalizers before delete: %v", shard.Finalizers)
-	if err := client.Delete(ctx, shard); err != nil {
+	if err := configClient.Delete(ctx, shard); err != nil {
 		t.Fatalf("Failed to delete Shard: %v", err)
 	}
 
@@ -147,24 +148,25 @@ func TestCreateShard(t *testing.T) {
 func TestShardBundleAnnotation(t *testing.T) {
 	ctrlruntime.SetLogger(logr.Discard())
 
-	client := utils.GetKubeClient(t)
+	configClient := utils.GetConfigKubeClient(t)
+	workloadClient := utils.GetWorkloadKubeClient(t)
 	ctx := context.Background()
 
 	// create namespace
-	namespace := utils.CreateSelfDestructingNamespace(t, ctx, client, "shard-bundle-annotation")
+	namespace := utils.CreateSelfDestructingNamespace(t, ctx, configClient, "shard-bundle-annotation")
 
 	// deploy a root shard incl. etcd
-	rootShard := utils.DeployRootShard(ctx, t, client, namespace.Name, "")
+	rootShard := utils.DeployRootShard(ctx, t, configClient, workloadClient, namespace.Name, "")
 
 	// deploy a shard without bundle annotation first
 	shardName := "annotated-shard"
 	t.Log("Deploying Shard without bundle annotation...")
-	shard := utils.DeployShard(ctx, t, client, namespace.Name, shardName, rootShard.Name)
+	shard := utils.DeployShard(ctx, t, configClient, workloadClient, namespace.Name, shardName, rootShard.Name)
 
 	// verify no bundle exists yet
 	bundleName := fmt.Sprintf("%s-bundle", shard.Name)
 	bundle := &operatorv1alpha1.Bundle{}
-	err := client.Get(ctx, types.NamespacedName{
+	err := configClient.Get(ctx, types.NamespacedName{
 		Namespace: namespace.Name,
 		Name:      bundleName,
 	}, bundle)
@@ -174,7 +176,7 @@ func TestShardBundleAnnotation(t *testing.T) {
 
 	// add bundle annotation to the shard
 	t.Log("Adding bundle annotation to Shard...")
-	if err := client.Get(ctx, types.NamespacedName{
+	if err := configClient.Get(ctx, types.NamespacedName{
 		Namespace: namespace.Name,
 		Name:      shard.Name,
 	}, &shard); err != nil {
@@ -186,19 +188,19 @@ func TestShardBundleAnnotation(t *testing.T) {
 	}
 	shard.Annotations[resources.BundleAnnotation] = "true"
 
-	if err := client.Update(ctx, &shard); err != nil {
+	if err := configClient.Update(ctx, &shard); err != nil {
 		t.Fatalf("Failed to update shard with bundle annotation: %v", err)
 	}
 
 	// wait for bundle to be created
 	t.Log("Waiting for Bundle to be created...")
-	utils.WaitForObject(t, ctx, client, bundle, types.NamespacedName{
+	utils.WaitForObject(t, ctx, configClient, bundle, types.NamespacedName{
 		Namespace: namespace.Name,
 		Name:      bundleName,
 	})
 
 	// verify bundle was created
-	if err := client.Get(ctx, types.NamespacedName{
+	if err := configClient.Get(ctx, types.NamespacedName{
 		Namespace: namespace.Name,
 		Name:      bundleName,
 	}, bundle); err != nil {
@@ -224,7 +226,7 @@ func TestShardBundleAnnotation(t *testing.T) {
 			t.Fatalf("Timeout waiting for bundle to become Ready. Current state: %s, objects: %d/%d, conditions: %+v",
 				bundle.Status.State, len(bundle.Status.Objects), expectedObjects, bundle.Status.Conditions)
 		case <-ticker.C:
-			if err := client.Get(ctx, types.NamespacedName{
+			if err := configClient.Get(ctx, types.NamespacedName{
 				Namespace: namespace.Name,
 				Name:      bundleName,
 			}, bundle); err != nil {

--- a/test/e2e/shards/shards_test.go
+++ b/test/e2e/shards/shards_test.go
@@ -146,6 +146,9 @@ func TestCreateShard(t *testing.T) {
 }
 
 func TestShardBundleAnnotation(t *testing.T) {
+	// Bundling is only allowed if the config and workload controllers run on the same cluster.
+	utils.SkipUnlessTopology(t, utils.TopologySingle)
+
 	ctrlruntime.SetLogger(logr.Discard())
 
 	configClient := utils.GetConfigKubeClient(t)

--- a/test/e2e/virtualworkspaces/virtualworkspaces_test.go
+++ b/test/e2e/virtualworkspaces/virtualworkspaces_test.go
@@ -61,14 +61,15 @@ func TestExternalVirtualWorkspace(t *testing.T) {
 
 	ctrlruntime.SetLogger(logr.Discard())
 
-	client := utils.GetKubeClient(t)
+	configClient := utils.GetConfigKubeClient(t)
+	workloadClient := utils.GetWorkloadKubeClient(t)
 	ctx := context.Background()
 
-	namespace := utils.CreateSelfDestructingNamespace(t, ctx, client, "external-vw")
+	namespace := utils.CreateSelfDestructingNamespace(t, ctx, configClient, "external-vw")
 
 	// Deploy the standalone, external kcp virtual-workspace (do not wait for readiness since both
 	// the root shard and the VW will need to have a little dance before both are ready).
-	vw := utils.DeployVirtualWorkspace(ctx, t, client, namespace.Name, "kcp-vw", false, func(vw *operatorv1alpha1.VirtualWorkspace) {
+	vw := utils.DeployVirtualWorkspace(ctx, t, configClient, workloadClient, namespace.Name, "kcp-vw", false, func(vw *operatorv1alpha1.VirtualWorkspace) {
 		vw.Spec.Target.RootShardRef = &corev1.LocalObjectReference{
 			Name: "r00t", // Must match the rootshard name
 		}
@@ -79,7 +80,7 @@ func TestExternalVirtualWorkspace(t *testing.T) {
 	externalHostname := fmt.Sprintf("front-proxy-front-proxy.%s.svc.cluster.local", namespace.Name)
 
 	// Deploy a root shard that uses the external VW (in-process VW is disabled).
-	rootShard := utils.DeployRootShard(ctx, t, client, namespace.Name, externalHostname, func(rs *operatorv1alpha1.RootShard) {
+	rootShard := utils.DeployRootShard(ctx, t, configClient, workloadClient, namespace.Name, externalHostname, func(rs *operatorv1alpha1.RootShard) {
 		// Point the root shard to use our external VW instead of the in-process one.
 		rs.Spec.KCPVirtualWorkspace = &corev1.LocalObjectReference{
 			Name: vw.Name,
@@ -91,7 +92,7 @@ func TestExternalVirtualWorkspace(t *testing.T) {
 	})
 
 	// deploy front-proxy
-	utils.DeployFrontProxy(ctx, t, client, namespace.Name, rootShard.Name, externalHostname, func(fp *operatorv1alpha1.FrontProxy) {
+	utils.DeployFrontProxy(ctx, t, configClient, workloadClient, namespace.Name, rootShard.Name, externalHostname, func(fp *operatorv1alpha1.FrontProxy) {
 		fp.Spec.Resources = lowResourceRequirements()
 	})
 
@@ -104,7 +105,7 @@ func TestExternalVirtualWorkspace(t *testing.T) {
 			"app.kubernetes.io/instance":  vw.Name,
 		},
 	}
-	utils.WaitForPods(t, ctx, client, vwPodOpts...)
+	utils.WaitForPods(t, ctx, workloadClient, vwPodOpts...)
 
 	// Create a kubeconfig to access the root shard.
 	configSecretName := "kubeconfig"
@@ -129,13 +130,13 @@ func TestExternalVirtualWorkspace(t *testing.T) {
 	}
 
 	t.Log("Creating kubeconfig for RootShard...")
-	if err := client.Create(ctx, &rsConfig); err != nil {
+	if err := configClient.Create(ctx, &rsConfig); err != nil {
 		t.Fatal(err)
 	}
-	utils.WaitForObject(t, ctx, client, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
+	utils.WaitForObject(t, ctx, configClient, &corev1.Secret{}, types.NamespacedName{Namespace: rsConfig.Namespace, Name: rsConfig.Spec.SecretRef.Name})
 
 	t.Log("Connecting to RootShard...")
-	rootShardClient := utils.ConnectWithKubeconfig(t, ctx, client, namespace.Name, rsConfig.Name, logicalcluster.None)
+	rootShardClient := utils.ConnectWithKubeconfig(t, ctx, configClient, namespace.Name, rsConfig.Name, logicalcluster.None)
 
 	// Proof of life: list something every logicalcluster in kcp has.
 	t.Log("Should be able to list Secrets in root workspace.")
@@ -182,7 +183,7 @@ func TestExternalVirtualWorkspace(t *testing.T) {
 
 	// Get the base kubeconfig secret
 	configSecret := &corev1.Secret{}
-	if err := client.Get(ctx, types.NamespacedName{Namespace: namespace.Name, Name: configSecretName}, configSecret); err != nil {
+	if err := configClient.Get(ctx, types.NamespacedName{Namespace: namespace.Name, Name: configSecretName}, configSecret); err != nil {
 		t.Fatalf("Failed to get kubeconfig secret: %v", err)
 	}
 
@@ -249,16 +250,17 @@ func TestMultipleShardsWithExternalVirtualWorkspacesAndExtCache(t *testing.T) {
 
 	ctrlruntime.SetLogger(logr.Discard())
 
-	client := utils.GetKubeClient(t)
+	configClient := utils.GetConfigKubeClient(t)
+	workloadClient := utils.GetWorkloadKubeClient(t)
 	ctx := context.Background()
 
-	namespace := utils.CreateSelfDestructingNamespace(t, ctx, client, "multi-shard-extcache-vw")
+	namespace := utils.CreateSelfDestructingNamespace(t, ctx, configClient, "multi-shard-extcache-vw")
 
 	// deploy the cache server
-	cacheServer := utils.DeployCacheServer(ctx, t, client, namespace.Name)
+	cacheServer := utils.DeployCacheServer(ctx, t, configClient, workloadClient, namespace.Name)
 
 	// Deploy external VirtualWorkspace for root shard
-	rootVW := utils.DeployVirtualWorkspace(ctx, t, client, namespace.Name, "root-vw", false, func(vw *operatorv1alpha1.VirtualWorkspace) {
+	rootVW := utils.DeployVirtualWorkspace(ctx, t, configClient, workloadClient, namespace.Name, "root-vw", false, func(vw *operatorv1alpha1.VirtualWorkspace) {
 		vw.Spec.Target.RootShardRef = &corev1.LocalObjectReference{
 			Name: "r00t",
 		}
@@ -269,7 +271,7 @@ func TestMultipleShardsWithExternalVirtualWorkspacesAndExtCache(t *testing.T) {
 	externalHostname := fmt.Sprintf("front-proxy-front-proxy.%s.svc.cluster.local", namespace.Name)
 
 	// Deploy root shard with external VW
-	rootShard := utils.DeployRootShard(ctx, t, client, namespace.Name, externalHostname, func(rs *operatorv1alpha1.RootShard) {
+	rootShard := utils.DeployRootShard(ctx, t, configClient, workloadClient, namespace.Name, externalHostname, func(rs *operatorv1alpha1.RootShard) {
 		rs.Spec.KCPVirtualWorkspace = &corev1.LocalObjectReference{
 			Name: rootVW.Name,
 		}
@@ -283,7 +285,7 @@ func TestMultipleShardsWithExternalVirtualWorkspacesAndExtCache(t *testing.T) {
 	})
 
 	// Deploy external VirtualWorkspace for regular shard1
-	shard1VW := utils.DeployVirtualWorkspace(ctx, t, client, namespace.Name, "shard1-vw", false, func(vw *operatorv1alpha1.VirtualWorkspace) {
+	shard1VW := utils.DeployVirtualWorkspace(ctx, t, configClient, workloadClient, namespace.Name, "shard1-vw", false, func(vw *operatorv1alpha1.VirtualWorkspace) {
 		vw.Spec.Target.ShardRef = &corev1.LocalObjectReference{
 			Name: "shard1",
 		}
@@ -291,7 +293,7 @@ func TestMultipleShardsWithExternalVirtualWorkspacesAndExtCache(t *testing.T) {
 	})
 
 	// Deploy regular shard1 with external VW
-	utils.DeployShard(ctx, t, client, namespace.Name, "shard1", rootShard.Name, func(s *operatorv1alpha1.Shard) {
+	utils.DeployShard(ctx, t, configClient, workloadClient, namespace.Name, "shard1", rootShard.Name, func(s *operatorv1alpha1.Shard) {
 		s.Spec.KCPVirtualWorkspace = &corev1.LocalObjectReference{
 			Name: shard1VW.Name,
 		}
@@ -299,24 +301,24 @@ func TestMultipleShardsWithExternalVirtualWorkspacesAndExtCache(t *testing.T) {
 	})
 
 	// Deploy another regular shard with internal VW
-	utils.DeployShard(ctx, t, client, namespace.Name, "shard2", rootShard.Name, func(s *operatorv1alpha1.Shard) {
+	utils.DeployShard(ctx, t, configClient, workloadClient, namespace.Name, "shard2", rootShard.Name, func(s *operatorv1alpha1.Shard) {
 		s.Spec.Resources = lowResourceRequirements()
 	})
 
 	// Deploy front-proxy
-	frontProxy := utils.DeployFrontProxy(ctx, t, client, namespace.Name, rootShard.Name, externalHostname, func(fp *operatorv1alpha1.FrontProxy) {
+	frontProxy := utils.DeployFrontProxy(ctx, t, configClient, workloadClient, namespace.Name, rootShard.Name, externalHostname, func(fp *operatorv1alpha1.FrontProxy) {
 		fp.Spec.Resources = lowResourceRequirements()
 	})
 
 	// Wait for both VirtualWorkspace pods to be ready
 	t.Log("Waiting for root VirtualWorkspace pods to be ready...")
-	waitForVirtualWorkspacePods(t, ctx, client, rootVW.Namespace, rootVW.Name)
+	waitForVirtualWorkspacePods(t, ctx, workloadClient, rootVW.Namespace, rootVW.Name)
 
 	t.Log("Waiting for shard VirtualWorkspace pods to be ready...")
-	waitForVirtualWorkspacePods(t, ctx, client, shard1VW.Namespace, shard1VW.Name)
+	waitForVirtualWorkspacePods(t, ctx, workloadClient, shard1VW.Namespace, shard1VW.Name)
 
 	// verify the setup
-	test := conformance.NewWorkspaceSchedulingTest(frontProxy.Name, client, namespace.Name)
+	test := conformance.NewWorkspaceSchedulingTest(frontProxy.Name, configClient, namespace.Name)
 
 	t.Log("Verifying workspace scheduling capabilities...")
 	if err := test.Run(t, ctx, logicalcluster.NewPath("root")); err != nil {
@@ -327,7 +329,7 @@ func TestMultipleShardsWithExternalVirtualWorkspacesAndExtCache(t *testing.T) {
 }
 
 // waitForVirtualWorkspacePods waits for VirtualWorkspace pods to become ready.
-func waitForVirtualWorkspacePods(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, namespace, name string) {
+func waitForVirtualWorkspacePods(t *testing.T, ctx context.Context, workloadClient ctrlruntimeclient.Client, namespace, name string) {
 	t.Helper()
 
 	opts := []ctrlruntimeclient.ListOption{
@@ -337,7 +339,7 @@ func waitForVirtualWorkspacePods(t *testing.T, ctx context.Context, client ctrlr
 			"app.kubernetes.io/instance":  name,
 		},
 	}
-	utils.WaitForPods(t, ctx, client, opts...)
+	utils.WaitForPods(t, ctx, workloadClient, opts...)
 }
 
 // lowResourceRequirements returns minimal resource requirements for testing.

--- a/test/syncer/main.go
+++ b/test/syncer/main.go
@@ -1,0 +1,352 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command syncer copies Compiled* resources between the config and workload cluster.
+//
+// Production setups will have their own setup to synchronise resources between
+// the config control plane and workload clusters, this is just a really simple
+// spec/status copier for the e2e tests.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	watchtools "k8s.io/client-go/tools/watch"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
+)
+
+var compiledKinds = map[string]string{
+	"CompiledCacheServer":      resources.CacheServerLabel,
+	"CompiledFrontProxy":       resources.FrontProxyLabel,
+	"CompiledRootShard":        resources.RootShardLabel,
+	"CompiledShard":            resources.ShardLabel,
+	"CompiledVirtualWorkspace": resources.VirtualWorkspaceLabel,
+}
+
+func main() {
+	var (
+		configKubeconfig   string
+		workloadKubeconfig string
+		namespacePrefix    string
+	)
+
+	flag.StringVar(&configKubeconfig, "config-kubeconfig", "", "Path to the kubeconfig for the config cluster.")
+	flag.StringVar(&workloadKubeconfig, "workload-kubeconfig", "", "Path to the kubeconfig for the workload cluster.")
+	flag.StringVar(&namespacePrefix, "namespace-prefix", "e2e-", "Only sync namespaces with this prefix.")
+	flag.Parse()
+
+	if configKubeconfig == "" || workloadKubeconfig == "" {
+		log.Fatal("Both --config-kubeconfig and --workload-kubeconfig must be set.")
+	}
+
+	configClient, err := newClient(configKubeconfig)
+	if err != nil {
+		log.Fatalf("Failed to create config cluster client: %v.", err)
+	}
+
+	workloadClient, err := newClient(workloadKubeconfig)
+	if err != nil {
+		log.Fatalf("Failed to create workload cluster client: %v.", err)
+	}
+
+	ctx := ctrlruntime.SetupSignalHandler()
+	s := &syncer{
+		config:   configClient,
+		workload: workloadClient,
+		prefix:   namespacePrefix,
+	}
+
+	var wg sync.WaitGroup
+	for kind := range compiledKinds {
+		gvk := deployv1alpha1.SchemeGroupVersion.WithKind(kind)
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			watchKind(ctx, configClient, gvk, s.syncToWorkload, s.deleteFromWorkload)
+		}()
+		go func() {
+			defer wg.Done()
+			watchKind(ctx, workloadClient, gvk, s.syncStatusToConfig, nil)
+		}()
+	}
+	wg.Wait()
+}
+
+func newClient(kubeconfig string) (ctrlruntimeclient.WithWatch, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return ctrlruntimeclient.NewWithWatch(config, ctrlruntimeclient.Options{})
+}
+
+type eventHandler func(ctx context.Context, gvk schema.GroupVersionKind, obj *unstructured.Unstructured) error
+
+func watchKind(ctx context.Context, client ctrlruntimeclient.WithWatch, gvk schema.GroupVersionKind, upsert, delete eventHandler) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(gvk.GroupVersion().WithKind(gvk.Kind + "List"))
+	if err := client.List(ctx, list); err != nil {
+		log.Fatalf("Failed to list %s: %v.", gvk.Kind, err)
+	}
+
+	for i := range list.Items {
+		if err := upsert(ctx, gvk, &list.Items[i]); err != nil {
+			log.Printf("Failed to sync %s %s/%s: %v.", gvk.Kind, list.Items[i].GetNamespace(), list.Items[i].GetName(), err)
+		}
+	}
+
+	watcher, err := watchtools.NewRetryWatcherWithContext(ctx, list.GetResourceVersion(), &cache.ListWatch{
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			l := &unstructured.UnstructuredList{}
+			l.SetGroupVersionKind(gvk.GroupVersion().WithKind(gvk.Kind + "List"))
+			return client.Watch(ctx, l, &ctrlruntimeclient.ListOptions{Raw: &options})
+		},
+	})
+	if err != nil {
+		log.Fatalf("Failed to create watcher for %s: %v.", gvk.Kind, err)
+	}
+	defer watcher.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return
+			}
+
+			obj, isUnstructured := event.Object.(*unstructured.Unstructured)
+			if !isUnstructured {
+				continue
+			}
+
+			var err error
+			switch event.Type {
+			case watch.Added, watch.Modified:
+				err = upsert(ctx, gvk, obj)
+			case watch.Deleted:
+				if delete != nil {
+					err = delete(ctx, gvk, obj)
+				}
+			}
+			if err != nil {
+				log.Printf("Failed to sync %s %s/%s: %v.", gvk.Kind, obj.GetNamespace(), obj.GetName(), err)
+			}
+		}
+	}
+}
+
+type syncer struct {
+	config   ctrlruntimeclient.WithWatch
+	workload ctrlruntimeclient.WithWatch
+	prefix   string
+}
+
+// syncToWorkload copies the object and its related secrets and configmaps to the workload cluster.
+func (s *syncer) syncToWorkload(ctx context.Context, gvk schema.GroupVersionKind, obj *unstructured.Unstructured) error {
+	if !strings.HasPrefix(obj.GetNamespace(), s.prefix) {
+		return nil
+	}
+
+	if err := s.ensureNamespace(ctx, obj.GetNamespace()); err != nil {
+		return err
+	}
+
+	labelKey := compiledKinds[gvk.Kind]
+	if value := obj.GetLabels()[labelKey]; value != "" {
+		if err := s.syncSecrets(ctx, obj.GetNamespace(), labelKey, value); err != nil {
+			return err
+		}
+
+		if err := s.syncConfigMaps(ctx, obj.GetNamespace(), labelKey, value); err != nil {
+			return err
+		}
+	}
+
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(gvk)
+	if err := s.workload.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(obj), existing); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+
+		target := &unstructured.Unstructured{}
+		target.SetGroupVersionKind(gvk)
+		target.SetName(obj.GetName())
+		target.SetNamespace(obj.GetNamespace())
+		target.SetLabels(obj.GetLabels())
+		target.Object["spec"] = obj.Object["spec"]
+
+		log.Printf("Creating %s %s/%s on workload cluster.", gvk.Kind, obj.GetNamespace(), obj.GetName())
+		return s.workload.Create(ctx, target)
+	}
+
+	existing.SetLabels(obj.GetLabels())
+	existing.Object["spec"] = obj.Object["spec"]
+
+	return s.workload.Update(ctx, existing)
+}
+
+func (s *syncer) deleteFromWorkload(ctx context.Context, gvk schema.GroupVersionKind, obj *unstructured.Unstructured) error {
+	if !strings.HasPrefix(obj.GetNamespace(), s.prefix) {
+		return nil
+	}
+
+	toDelete := &unstructured.Unstructured{}
+	toDelete.SetGroupVersionKind(gvk)
+	toDelete.SetName(obj.GetName())
+	toDelete.SetNamespace(obj.GetNamespace())
+
+	log.Printf("Deleting %s %s/%s on workload cluster.", gvk.Kind, obj.GetNamespace(), obj.GetName())
+	return ctrlruntimeclient.IgnoreNotFound(s.workload.Delete(ctx, toDelete))
+}
+
+// syncStatusToConfig copies the status of the object back to the config cluster.
+func (s *syncer) syncStatusToConfig(ctx context.Context, gvk schema.GroupVersionKind, obj *unstructured.Unstructured) error {
+	if !strings.HasPrefix(obj.GetNamespace(), s.prefix) {
+		return nil
+	}
+
+	status, ok := obj.Object["status"].(map[string]any)
+	if !ok || len(status) == 0 {
+		return nil
+	}
+
+	configObj := &unstructured.Unstructured{}
+	configObj.SetGroupVersionKind(gvk)
+	if err := s.config.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(obj), configObj); err != nil {
+		return ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	configObj.Object["status"] = status
+
+	return s.config.Status().Update(ctx, configObj)
+}
+
+func (s *syncer) ensureNamespace(ctx context.Context, name string) error {
+	err := s.workload.Get(ctx, types.NamespacedName{Name: name}, &corev1.Namespace{})
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	log.Printf("Creating namespace %s on workload cluster.", name)
+
+	return s.workload.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	})
+}
+
+func (s *syncer) syncSecrets(ctx context.Context, namespace, labelKey, labelValue string) error {
+	secrets := &corev1.SecretList{}
+	if err := s.config.List(ctx, secrets, ctrlruntimeclient.InNamespace(namespace), ctrlruntimeclient.MatchingLabels{labelKey: labelValue}); err != nil {
+		return err
+	}
+
+	for _, secret := range secrets.Items {
+		existing := &corev1.Secret{}
+		err := s.workload.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(&secret), existing)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+
+			target := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secret.Name,
+					Namespace: secret.Namespace,
+					Labels:    secret.Labels,
+				},
+				Type: secret.Type,
+				Data: secret.Data,
+			}
+			if err := s.workload.Create(ctx, target); err != nil {
+				return err
+			}
+			continue
+		}
+
+		existing.Labels = secret.Labels
+		existing.Data = secret.Data
+		if err := s.workload.Update(ctx, existing); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *syncer) syncConfigMaps(ctx context.Context, namespace, labelKey, labelValue string) error {
+	configMaps := &corev1.ConfigMapList{}
+	if err := s.config.List(ctx, configMaps, ctrlruntimeclient.InNamespace(namespace), ctrlruntimeclient.MatchingLabels{labelKey: labelValue}); err != nil {
+		return err
+	}
+
+	for _, configMap := range configMaps.Items {
+		existing := &corev1.ConfigMap{}
+		err := s.workload.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(&configMap), existing)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+
+			target := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMap.Name,
+					Namespace: configMap.Namespace,
+					Labels:    configMap.Labels,
+				},
+				Data:       configMap.Data,
+				BinaryData: configMap.BinaryData,
+			}
+			if err := s.workload.Create(ctx, target); err != nil {
+				return err
+			}
+			continue
+		}
+
+		existing.Labels = configMap.Labels
+		existing.Data = configMap.Data
+		existing.BinaryData = configMap.BinaryData
+		if err := s.workload.Update(ctx, existing); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/test/utils/deploy.go
+++ b/test/utils/deploy.go
@@ -30,27 +30,41 @@ import (
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
+func workloadKubeconfig(t *testing.T) string {
+	t.Helper()
+
+	kubeconfig := os.Getenv("WORKLOAD_KUBECONFIG")
+	if kubeconfig == "" {
+		t.Fatal("WORKLOAD_KUBECONFIG is not set.")
+	}
+
+	return kubeconfig
+}
+
+// DeployEtcd deploys etcd onto the workload cluster, where the kcp pods run.
 func DeployEtcd(t *testing.T, name, namespace string) string {
 	t.Helper()
 
 	helmChart := os.Getenv("ETCD_HELM_CHART")
+	kubeconfig := workloadKubeconfig(t)
 
 	t.Logf("Installing etcd %q into %s...", name, namespace)
-	args := []string{"install", "--namespace", namespace, "--atomic", name, helmChart}
+	args := []string{"install", "--kubeconfig", kubeconfig, "--namespace", namespace, "--create-namespace", "--atomic", name, helmChart}
 
 	helmCommand := os.Getenv("HELM_BINARY")
 	if helmCommand == "" {
 		helmCommand = "helm"
 	}
 
-	if err := exec.Command(helmCommand, args...).Run(); err != nil {
-		t.Fatalf("Failed to deploy etcd: %v", err)
+	if out, err := exec.Command(helmCommand, args...).CombinedOutput(); err != nil {
+		t.Fatalf("Failed to deploy etcd: %v\n%s", err, out)
 	}
 
 	t.Log("Waiting for etcd to get ready...")
 	args = []string{
 		"wait",
 		"pods",
+		"--kubeconfig", kubeconfig,
 		"--namespace", namespace,
 		"--selector", fmt.Sprintf("app.kubernetes.io/name=etcd,app.kubernetes.io/instance=%s", name),
 		"--for", "condition=Ready",
@@ -83,7 +97,7 @@ func applyShardEnv(spec operatorv1alpha1.CommonShardSpec) operatorv1alpha1.Commo
 	return spec
 }
 
-func DeployShard(ctx context.Context, t *testing.T, client ctrlruntimeclient.Client, namespace, name, rootShard string, patches ...func(*operatorv1alpha1.Shard)) operatorv1alpha1.Shard {
+func DeployShard(ctx context.Context, t *testing.T, configClient, workloadClient ctrlruntimeclient.Client, namespace, name, rootShard string, patches ...func(*operatorv1alpha1.Shard)) operatorv1alpha1.Shard {
 	t.Helper()
 
 	etcd := DeployEtcd(t, "etcd-"+name, namespace)
@@ -110,7 +124,7 @@ func DeployShard(ctx context.Context, t *testing.T, client ctrlruntimeclient.Cli
 	}
 
 	t.Logf("Creating Shard %s...", shard.Name)
-	if err := client.Create(ctx, &shard); err != nil {
+	if err := configClient.Create(ctx, &shard); err != nil {
 		t.Fatal(err)
 	}
 
@@ -121,12 +135,12 @@ func DeployShard(ctx context.Context, t *testing.T, client ctrlruntimeclient.Cli
 			"app.kubernetes.io/instance":  shard.Name,
 		},
 	}
-	WaitForPods(t, ctx, client, opts...)
+	WaitForPods(t, ctx, workloadClient, opts...)
 
 	return shard
 }
 
-func DeployRootShard(ctx context.Context, t *testing.T, client ctrlruntimeclient.Client, namespace string, externalHostname string, patches ...func(*operatorv1alpha1.RootShard)) operatorv1alpha1.RootShard {
+func DeployRootShard(ctx context.Context, t *testing.T, configClient, workloadClient ctrlruntimeclient.Client, namespace string, externalHostname string, patches ...func(*operatorv1alpha1.RootShard)) operatorv1alpha1.RootShard {
 	t.Helper()
 
 	etcd := DeployEtcd(t, "etcd-r00t", namespace)
@@ -181,7 +195,7 @@ func DeployRootShard(ctx context.Context, t *testing.T, client ctrlruntimeclient
 	}
 
 	t.Logf("Creating RootShard %s...", rootShard.Name)
-	if err := client.Create(ctx, &rootShard); err != nil {
+	if err := configClient.Create(ctx, &rootShard); err != nil {
 		t.Fatal(err)
 	}
 
@@ -192,12 +206,12 @@ func DeployRootShard(ctx context.Context, t *testing.T, client ctrlruntimeclient
 			"app.kubernetes.io/instance":  rootShard.Name,
 		},
 	}
-	WaitForPods(t, ctx, client, opts...)
+	WaitForPods(t, ctx, workloadClient, opts...)
 
 	return rootShard
 }
 
-func DeployFrontProxy(ctx context.Context, t *testing.T, client ctrlruntimeclient.Client, namespace string, rootShardName string, externalHostname string, patches ...func(*operatorv1alpha1.FrontProxy)) operatorv1alpha1.FrontProxy {
+func DeployFrontProxy(ctx context.Context, t *testing.T, configClient, workloadClient ctrlruntimeclient.Client, namespace string, rootShardName string, externalHostname string, patches ...func(*operatorv1alpha1.FrontProxy)) operatorv1alpha1.FrontProxy {
 	t.Helper()
 
 	frontProxy := operatorv1alpha1.FrontProxy{}
@@ -234,7 +248,7 @@ func DeployFrontProxy(ctx context.Context, t *testing.T, client ctrlruntimeclien
 	}
 
 	t.Logf("Creating FrontProxy %s...", frontProxy.Name)
-	if err := client.Create(ctx, &frontProxy); err != nil {
+	if err := configClient.Create(ctx, &frontProxy); err != nil {
 		t.Fatal(err)
 	}
 
@@ -245,12 +259,12 @@ func DeployFrontProxy(ctx context.Context, t *testing.T, client ctrlruntimeclien
 			"app.kubernetes.io/instance":  frontProxy.Name,
 		},
 	}
-	WaitForPods(t, ctx, client, opts...)
+	WaitForPods(t, ctx, workloadClient, opts...)
 
 	return frontProxy
 }
 
-func DeployCacheServer(ctx context.Context, t *testing.T, client ctrlruntimeclient.Client, namespace string, patches ...func(*operatorv1alpha1.CacheServer)) operatorv1alpha1.CacheServer {
+func DeployCacheServer(ctx context.Context, t *testing.T, configClient, workloadClient ctrlruntimeclient.Client, namespace string, patches ...func(*operatorv1alpha1.CacheServer)) operatorv1alpha1.CacheServer {
 	t.Helper()
 
 	server := operatorv1alpha1.CacheServer{}
@@ -274,7 +288,7 @@ func DeployCacheServer(ctx context.Context, t *testing.T, client ctrlruntimeclie
 	}
 
 	t.Logf("Creating CacheServer %s...", server.Name)
-	if err := client.Create(ctx, &server); err != nil {
+	if err := configClient.Create(ctx, &server); err != nil {
 		t.Fatal(err)
 	}
 
@@ -285,17 +299,17 @@ func DeployCacheServer(ctx context.Context, t *testing.T, client ctrlruntimeclie
 			"app.kubernetes.io/instance":  server.Name,
 		},
 	}
-	WaitForPods(t, ctx, client, opts...)
+	WaitForPods(t, ctx, workloadClient, opts...)
 
 	return server
 }
 
-func DeployCacheServerWithExternalEtcd(ctx context.Context, t *testing.T, client ctrlruntimeclient.Client, namespace string, replicas int32, patches ...func(*operatorv1alpha1.CacheServer)) operatorv1alpha1.CacheServer {
+func DeployCacheServerWithExternalEtcd(ctx context.Context, t *testing.T, configClient, workloadClient ctrlruntimeclient.Client, namespace string, replicas int32, patches ...func(*operatorv1alpha1.CacheServer)) operatorv1alpha1.CacheServer {
 	t.Helper()
 
 	etcd := DeployEtcd(t, "kachy-etcd", namespace)
 
-	return DeployCacheServer(ctx, t, client, namespace, append(patches, func(server *operatorv1alpha1.CacheServer) {
+	return DeployCacheServer(ctx, t, configClient, workloadClient, namespace, append(patches, func(server *operatorv1alpha1.CacheServer) {
 		server.Spec.Replicas = &replicas
 		server.Spec.Etcd = &operatorv1alpha1.EtcdConfig{
 			Endpoints: []string{etcd},
@@ -303,7 +317,7 @@ func DeployCacheServerWithExternalEtcd(ctx context.Context, t *testing.T, client
 	})...)
 }
 
-func DeployVirtualWorkspace(ctx context.Context, t *testing.T, client ctrlruntimeclient.Client, namespace, name string, waitForReady bool, patches ...func(*operatorv1alpha1.VirtualWorkspace)) operatorv1alpha1.VirtualWorkspace {
+func DeployVirtualWorkspace(ctx context.Context, t *testing.T, configClient, workloadClient ctrlruntimeclient.Client, namespace, name string, waitForReady bool, patches ...func(*operatorv1alpha1.VirtualWorkspace)) operatorv1alpha1.VirtualWorkspace {
 	t.Helper()
 
 	vw := operatorv1alpha1.VirtualWorkspace{}
@@ -327,7 +341,7 @@ func DeployVirtualWorkspace(ctx context.Context, t *testing.T, client ctrlruntim
 	}
 
 	t.Logf("Creating VirtualWorkspace %s...", vw.Name)
-	if err := client.Create(ctx, &vw); err != nil {
+	if err := configClient.Create(ctx, &vw); err != nil {
 		t.Fatal(err)
 	}
 
@@ -339,7 +353,7 @@ func DeployVirtualWorkspace(ctx context.Context, t *testing.T, client ctrlruntim
 				"app.kubernetes.io/instance":  vw.Name,
 			},
 		}
-		WaitForPods(t, ctx, client, opts...)
+		WaitForPods(t, ctx, workloadClient, opts...)
 	}
 
 	return vw

--- a/test/utils/topology.go
+++ b/test/utils/topology.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+	"testing"
+)
+
+const (
+	// TopologySingle is a single cluster running both controller groups.
+	TopologySingle = "single"
+	// TopologyConfigWorkload is a config and a workload cluster, each running only its controller group.
+	TopologyConfigWorkload = "config-workload"
+)
+
+func Topology() string {
+	if topology := os.Getenv("E2E_TOPOLOGY"); topology != "" {
+		return topology
+	}
+
+	return ""
+}
+
+func SkipUnlessTopology(t *testing.T, topology string) {
+	if current := Topology(); current != topology {
+		t.Skipf("Test requires the %s topology, but the harness is running %s.", topology, current)
+	}
+}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -37,6 +37,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/scale/scheme"
 	"k8s.io/client-go/tools/clientcmd"
@@ -44,6 +45,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kcp-dev/kcp-operator/internal/resources"
+	deployv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/deploy/v1alpha1"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -73,19 +75,26 @@ func GetSelfSignedIssuerRef() *operatorv1alpha1.ObjectReference {
 	}
 }
 
-func GetKubeClient(t *testing.T) ctrlruntimeclient.Client {
+func newKubeScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 
 	sc := runtime.NewScheme()
-	if err := scheme.AddToScheme(sc); err != nil {
-		t.Fatal(err)
-	}
-	if err := corev1.AddToScheme(sc); err != nil {
+	if err := clientgoscheme.AddToScheme(sc); err != nil {
 		t.Fatal(err)
 	}
 	if err := operatorv1alpha1.AddToScheme(sc); err != nil {
 		t.Fatal(err)
 	}
+	if err := deployv1alpha1.AddToScheme(sc); err != nil {
+		t.Fatal(err)
+	}
+
+	return sc
+}
+
+// GetConfigKubeClient returns a client for the config cluster.
+func GetConfigKubeClient(t *testing.T) ctrlruntimeclient.Client {
+	t.Helper()
 
 	config, err := ctrlruntime.GetConfig()
 	if err != nil {
@@ -93,7 +102,26 @@ func GetKubeClient(t *testing.T) ctrlruntimeclient.Client {
 	}
 
 	c, err := ctrlruntimeclient.New(config, ctrlruntimeclient.Options{
-		Scheme: sc,
+		Scheme: newKubeScheme(t),
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	return c
+}
+
+// GetWorkloadKubeClient returns a client for the workload cluster.
+func GetWorkloadKubeClient(t *testing.T) ctrlruntimeclient.Client {
+	t.Helper()
+
+	config, err := clientcmd.BuildConfigFromFlags("", workloadKubeconfig(t))
+	if err != nil {
+		t.Fatalf("Failed to get workload kubeconfig: %v", err)
+	}
+
+	c, err := ctrlruntimeclient.New(config, ctrlruntimeclient.Options{
+		Scheme: newKubeScheme(t),
 	})
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
@@ -123,6 +151,8 @@ func CreateSelfDestructingNamespace(t *testing.T, ctx context.Context, client ct
 	return &ns
 }
 
+// SelfDestuctingPortForward forwards a port on the workload cluster,
+// where the kcp pods run, to a local port.
 func SelfDestuctingPortForward(
 	t *testing.T,
 	ctx context.Context,
@@ -135,6 +165,7 @@ func SelfDestuctingPortForward(
 
 	args := []string{
 		"port-forward",
+		"--kubeconfig", workloadKubeconfig(t),
 		"--namespace", namespace,
 		target,
 		fmt.Sprintf("%d:%d", localPort, targetPort),
@@ -192,20 +223,20 @@ func getPort(t *testing.T) int {
 	return portNum
 }
 
-func getGeneratedKubeconfig(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, namespace string, kubeconfigName string) *rest.Config {
+func getGeneratedKubeconfig(t *testing.T, ctx context.Context, configClient ctrlruntimeclient.Client, namespace string, kubeconfigName string) *rest.Config {
 	t.Helper()
 
 	// get kubeconfig
 	config := &operatorv1alpha1.Kubeconfig{}
 	key := types.NamespacedName{Namespace: namespace, Name: kubeconfigName}
-	if err := client.Get(ctx, key, config); err != nil {
+	if err := configClient.Get(ctx, key, config); err != nil {
 		t.Fatal(err)
 	}
 
 	// get the kubeconfig's secret
 	secret := &corev1.Secret{}
 	key = types.NamespacedName{Namespace: namespace, Name: config.Spec.SecretRef.Name}
-	if err := client.Get(ctx, key, secret); err != nil {
+	if err := configClient.Get(ctx, key, secret); err != nil {
 		t.Fatal(err)
 	}
 
@@ -221,7 +252,7 @@ func getGeneratedKubeconfig(t *testing.T, ctx context.Context, client ctrlruntim
 func ConnectWithKubeconfig(
 	t *testing.T,
 	ctx context.Context,
-	client ctrlruntimeclient.Client,
+	configClient ctrlruntimeclient.Client,
 	namespace string,
 	kubeconfigName string,
 	cluster logicalcluster.Path,
@@ -229,7 +260,7 @@ func ConnectWithKubeconfig(
 	t.Helper()
 
 	// get kubeconfig
-	clientConfig := getGeneratedKubeconfig(t, ctx, client, namespace, kubeconfigName)
+	clientConfig := getGeneratedKubeconfig(t, ctx, configClient, namespace, kubeconfigName)
 
 	// deduce service name from the hostname
 	parsed, err := url.Parse(clientConfig.Host)
@@ -261,14 +292,14 @@ func ConnectWithKubeconfig(
 func KubeconfigClusterClient(
 	t *testing.T,
 	ctx context.Context,
-	client ctrlruntimeclient.Client,
+	configClient ctrlruntimeclient.Client,
 	namespace string,
 	kubeconfigName string,
 ) ClusterClient {
 	t.Helper()
 
 	// get kubeconfig
-	clientConfig := getGeneratedKubeconfig(t, ctx, client, namespace, kubeconfigName)
+	clientConfig := getGeneratedKubeconfig(t, ctx, configClient, namespace, kubeconfigName)
 
 	// deduce service name from the hostname
 	parsed, err := url.Parse(clientConfig.Host)
@@ -291,7 +322,7 @@ func KubeconfigClusterClient(
 func ConnectWithRootShardProxy(
 	t *testing.T,
 	ctx context.Context,
-	client ctrlruntimeclient.Client,
+	configClient ctrlruntimeclient.Client,
 	rootShard *operatorv1alpha1.RootShard,
 	cluster logicalcluster.Path,
 ) ctrlruntimeclient.Client {
@@ -304,7 +335,7 @@ func ConnectWithRootShardProxy(
 	}
 
 	certSecret := &corev1.Secret{}
-	if err := client.Get(ctx, key, certSecret); err != nil {
+	if err := configClient.Get(ctx, key, certSecret); err != nil {
 		t.Fatalf("Failed to get root shard proxy Secret: %v", err)
 	}
 


### PR DESCRIPTION
This PR is part of a stacked PR that splits kcp-operator's functionality
into two controller groups, `config` and `workload` and adds an
intermediate resource group deploy.operator.kcp.io. The config
controller group prepares and compiles resources into resources of the
group deploy.operator.kcp.io.

The `workload` then realizes the compiled resource into workload
resources (`Deployment` and `Service`).

```release-note
NONE
```

/kind feature

