### PR TITLE
Gather shards in controllers and thread through

### DIFF
--- a/internal/controller/frontproxy/controller.go
+++ b/internal/controller/frontproxy/controller.go
@@ -144,7 +144,12 @@ func (r *FrontProxyReconciler) reconcile(ctx context.Context, frontProxy *operat
 		return conditions, nil
 	}
 
-	fpReconciler := frontproxy.NewFrontProxy(frontProxy, rootShard)
+	shards, err := util.GetRootShardChildren(ctx, r.Client, rootShard)
+	if err != nil {
+		return conditions, fmt.Errorf("failed to list shards: %w", err)
+	}
+
+	fpReconciler := frontproxy.NewFrontProxy(frontProxy, rootShard, shards)
 
 	// Deployment will be scaled to 0 if bundle annotation is present
 	if err := fpReconciler.Reconcile(ctx, r.Client, frontProxy.Namespace); err != nil {

--- a/internal/controller/rootshard/controller.go
+++ b/internal/controller/rootshard/controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -334,10 +333,6 @@ func (r *RootShardReconciler) reconcileStatus(ctx context.Context, oldRootShard 
 			rootShard.Status.Shards[i] = operatorv1alpha1.ShardReference{Name: shard.Name}
 		}
 	}
-	// sort the shards by name for equality comparison
-	sort.Slice(rootShard.Status.Shards, func(i, j int) bool {
-		return rootShard.Status.Shards[i].Name < rootShard.Status.Shards[j].Name
-	})
 
 	// only patch the status if there are actual changes.
 	if !equality.Semantic.DeepEqual(oldRootShard.Status, rootShard.Status) {

--- a/internal/controller/rootshard/controller.go
+++ b/internal/controller/rootshard/controller.go
@@ -249,10 +249,15 @@ func (r *RootShardReconciler) reconcile(ctx context.Context, rootShard *operator
 		}
 	}
 
+	shards, shardsErr := util.GetRootShardChildren(ctx, r.Client, rootShard)
+	if shardsErr != nil {
+		errs = append(errs, fmt.Errorf("failed to list shards: %w", shardsErr))
+	}
+
 	// Deployment will be scaled to 0 if bundle annotation is present
-	if vwConfigValid {
+	if vwConfigValid && shardsErr == nil {
 		if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{
-			rootshard.DeploymentReconciler(rootShard, kcpVW),
+			rootshard.DeploymentReconciler(rootShard, kcpVW, shards),
 		}, rootShard.Namespace, r.Client, ownerRefWrapper, revisionLabels); err != nil {
 			// Swallow these errors and instead rely on us watching Secrets and re-reconciling whenever they change.
 			if !errors.Is(err, modifier.ErrMountNotFound) {
@@ -334,7 +339,7 @@ func (r *RootShardReconciler) reconcileStatus(ctx context.Context, oldRootShard 
 		}
 	}
 
-	// only patch the status if there are actual changes.
+	// No reconciler reads Status.Shards, but this write is what wakes the Shard and FrontProxy controllers through their RootShard watches.
 	if !equality.Semantic.DeepEqual(oldRootShard.Status, rootShard.Status) {
 		if err := r.Status().Patch(ctx, rootShard, ctrlruntimeclient.MergeFrom(oldRootShard)); err != nil {
 			errs = append(errs, err)

--- a/internal/controller/shard/controller.go
+++ b/internal/controller/shard/controller.go
@@ -237,10 +237,15 @@ func (r *ShardReconciler) reconcile(ctx context.Context, s *operatorv1alpha1.Sha
 		}
 	}
 
+	shards, shardsErr := util.GetRootShardChildren(ctx, r.Client, rootShard)
+	if shardsErr != nil {
+		errs = append(errs, fmt.Errorf("failed to list shards: %w", shardsErr))
+	}
+
 	// Deployment will be scaled to 0 if bundle annotation is present
-	if vwConfigValid {
+	if vwConfigValid && shardsErr == nil {
 		if err := k8creconciling.ReconcileDeployments(ctx, []k8creconciling.NamedDeploymentReconcilerFactory{
-			shard.DeploymentReconciler(s, rootShard, kcpVW),
+			shard.DeploymentReconciler(s, rootShard, kcpVW, shards),
 		}, s.Namespace, r.Client, ownerRefWrapper, revisionLabels); err != nil {
 			// Swallow these errors and instead rely on us watching Secrets and re-reconciling whenever they change.
 			if !errors.Is(err, modifier.ErrMountNotFound) {

--- a/internal/controller/util/util.go
+++ b/internal/controller/util/util.go
@@ -19,6 +19,8 @@ package util
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -120,6 +122,7 @@ func FetchRootShard(ctx context.Context, client ctrlruntimeclient.Client, namesp
 }
 
 // GetRootShardChildren returns all shards that are currently registered with the given root shard.
+// The shards are sorted by name before returning.
 func GetRootShardChildren(ctx context.Context, client ctrlruntimeclient.Client, rootShard *operatorv1alpha1.RootShard) ([]operatorv1alpha1.Shard, error) {
 	var errs []error
 
@@ -137,6 +140,10 @@ func GetRootShardChildren(ctx context.Context, client ctrlruntimeclient.Client, 
 			result = append(result, shard)
 		}
 	}
+
+	slices.SortFunc(result, func(a, b operatorv1alpha1.Shard) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	return result, kerrors.NewAggregate(errs)
 }

--- a/internal/resources/frontproxy/ca_bundle_test.go
+++ b/internal/resources/frontproxy/ca_bundle_test.go
@@ -146,7 +146,7 @@ func TestMergedClientCASecretReconciler(t *testing.T) {
 				WithObjects(objects...).
 				Build()
 
-			rec := NewFrontProxy(tt.frontProxy, tt.rootShard)
+			rec := NewFrontProxy(tt.frontProxy, tt.rootShard, nil)
 
 			// Fetch the ClientCA data
 			clientCACert := tt.clientCASecret.Data["tls.crt"]

--- a/internal/resources/frontproxy/configmap_test.go
+++ b/internal/resources/frontproxy/configmap_test.go
@@ -83,7 +83,7 @@ func TestDefaultPathMappings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rec := NewFrontProxy(tt.frontProxy, tt.rootShard)
+			rec := NewFrontProxy(tt.frontProxy, tt.rootShard, nil)
 			mappings := rec.defaultPathMappings()
 
 			require.Len(t, mappings, 2)

--- a/internal/resources/frontproxy/deployment.go
+++ b/internal/resources/frontproxy/deployment.go
@@ -226,7 +226,7 @@ func (r *reconciler) deploymentReconciler() reconciling.NamedDeploymentReconcile
 			dep = utils.ApplyDeploymentTemplate(dep, template)
 
 			if r.frontProxy != nil {
-				dep = utils.ApplyAuthConfiguration(dep, r.frontProxy.Spec.Auth, r.rootShard)
+				dep = utils.ApplyAuthConfiguration(dep, r.frontProxy.Spec.Auth, r.rootShard, r.shards)
 
 				// If frontproxy has bundle annotation, store desired replicas in annotation then scale deployment to 0 locally
 				if r.frontProxy.Annotations != nil && r.frontProxy.Annotations[resources.BundleAnnotation] != "" {

--- a/internal/resources/frontproxy/deployment_test.go
+++ b/internal/resources/frontproxy/deployment_test.go
@@ -39,6 +39,7 @@ func TestDeploymentReconciler(t *testing.T) {
 		name           string
 		frontProxy     *operatorv1alpha1.FrontProxy
 		rootShard      *operatorv1alpha1.RootShard
+		shards         []operatorv1alpha1.Shard
 		expectedName   string
 		validateDeploy func(*testing.T, *appsv1.Deployment)
 	}{
@@ -366,16 +367,10 @@ func TestDeploymentReconciler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-root-shard",
 				},
-				Status: operatorv1alpha1.RootShardStatus{
-					Shards: []operatorv1alpha1.ShardReference{
-						{
-							Name: "test-root-shard",
-						},
-						{
-							Name: "test-shard-2",
-						},
-					},
-				},
+			},
+			shards: []operatorv1alpha1.Shard{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-root-shard"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-shard-2"}},
 			},
 			expectedName: resources.GetFrontProxyDeploymentName(&operatorv1alpha1.FrontProxy{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-front-proxy"},
@@ -599,7 +594,7 @@ func TestDeploymentReconciler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fpReconciler := NewFrontProxy(tt.frontProxy, tt.rootShard)
+			fpReconciler := NewFrontProxy(tt.frontProxy, tt.rootShard, tt.shards)
 			name, reconcilerFunc := fpReconciler.deploymentReconciler()()
 
 			assert.Equal(t, tt.expectedName, name)
@@ -770,6 +765,7 @@ func TestGetArgs(t *testing.T) {
 			rec := NewFrontProxy(
 				&operatorv1alpha1.FrontProxy{Spec: *tt.spec},
 				&operatorv1alpha1.RootShard{},
+				nil,
 			)
 
 			result := rec.getArgs(tt.version)

--- a/internal/resources/frontproxy/reconciler.go
+++ b/internal/resources/frontproxy/reconciler.go
@@ -38,10 +38,11 @@ import (
 type reconciler struct {
 	frontProxy     *operatorv1alpha1.FrontProxy
 	rootShard      *operatorv1alpha1.RootShard
+	shards         []operatorv1alpha1.Shard
 	resourceLabels map[string]string
 }
 
-func NewFrontProxy(frontProxy *operatorv1alpha1.FrontProxy, rootShard *operatorv1alpha1.RootShard) *reconciler {
+func NewFrontProxy(frontProxy *operatorv1alpha1.FrontProxy, rootShard *operatorv1alpha1.RootShard, shards []operatorv1alpha1.Shard) *reconciler {
 	if frontProxy == nil {
 		panic("Use NewRootShardProxy instead.")
 	}
@@ -49,6 +50,7 @@ func NewFrontProxy(frontProxy *operatorv1alpha1.FrontProxy, rootShard *operatorv
 	return &reconciler{
 		frontProxy:     frontProxy,
 		rootShard:      rootShard,
+		shards:         shards,
 		resourceLabels: resources.GetFrontProxyResourceLabels(frontProxy),
 	}
 }

--- a/internal/resources/frontproxy/service_test.go
+++ b/internal/resources/frontproxy/service_test.go
@@ -211,7 +211,7 @@ func TestGetExternalPort(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var rec *reconciler
 			if tt.frontProxy != nil {
-				rec = NewFrontProxy(tt.frontProxy, tt.rootShard)
+				rec = NewFrontProxy(tt.frontProxy, tt.rootShard, nil)
 			} else {
 				rec = NewRootShardProxy(tt.rootShard)
 			}

--- a/internal/resources/rootshard/deployment.go
+++ b/internal/resources/rootshard/deployment.go
@@ -76,7 +76,7 @@ func getCacheServerClientCertMountPath() string {
 	return "/etc/cache-server/tls/client-certificate"
 }
 
-func DeploymentReconciler(rootShard *operatorv1alpha1.RootShard, kcpVW *operatorv1alpha1.VirtualWorkspace) reconciling.NamedDeploymentReconcilerFactory {
+func DeploymentReconciler(rootShard *operatorv1alpha1.RootShard, kcpVW *operatorv1alpha1.VirtualWorkspace, shards []operatorv1alpha1.Shard) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return resources.GetRootShardDeploymentName(rootShard), func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			labels := resources.GetRootShardResourceLabels(rootShard)
@@ -204,7 +204,7 @@ func DeploymentReconciler(rootShard *operatorv1alpha1.RootShard, kcpVW *operator
 			dep = utils.ApplyCommonShardDeploymentProperties(dep)
 			dep = utils.ApplyCommonShardConfig(dep, &rootShard.Spec.CommonShardSpec)
 			dep = utils.ApplyDeploymentTemplate(dep, rootShard.Spec.DeploymentTemplate)
-			dep = utils.ApplyAuthConfiguration(dep, rootShard.Spec.Auth, rootShard)
+			dep = utils.ApplyAuthConfiguration(dep, rootShard.Spec.Auth, rootShard, shards)
 
 			// If rootshard has bundle annotation, store desired replicas in annotation then scale deployment to 0 locally
 			if rootShard.Annotations != nil && rootShard.Annotations[resources.BundleAnnotation] != "" {

--- a/internal/resources/rootshard/deployment_test.go
+++ b/internal/resources/rootshard/deployment_test.go
@@ -34,6 +34,7 @@ func TestDeploymentReconciler(t *testing.T) {
 	tests := []struct {
 		name           string
 		rootShard      *operatorv1alpha1.RootShard
+		shards         []operatorv1alpha1.Shard
 		expectedName   string
 		validateDeploy func(*testing.T, *appsv1.Deployment)
 	}{
@@ -152,9 +153,9 @@ func TestDeploymentReconciler(t *testing.T) {
 						},
 					},
 				},
-				Status: operatorv1alpha1.RootShardStatus{
-					Shards: []operatorv1alpha1.ShardReference{{Name: "theseus"}},
-				},
+			},
+			shards: []operatorv1alpha1.Shard{
+				{ObjectMeta: metav1.ObjectMeta{Name: "theseus"}},
 			},
 			expectedName: resources.GetRootShardDeploymentName(&operatorv1alpha1.RootShard{
 				ObjectMeta: metav1.ObjectMeta{Name: "rooty"},
@@ -219,7 +220,7 @@ func TestDeploymentReconciler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			factory := DeploymentReconciler(tt.rootShard, nil)
+			factory := DeploymentReconciler(tt.rootShard, nil, tt.shards)
 			name, reconcilerFunc := factory()
 
 			assert.Equal(t, tt.expectedName, name)

--- a/internal/resources/shard/deployment.go
+++ b/internal/resources/shard/deployment.go
@@ -89,7 +89,7 @@ func getEffectiveCacheRef(shard *operatorv1alpha1.Shard, rootShard *operatorv1al
 	return ""
 }
 
-func DeploymentReconciler(shard *operatorv1alpha1.Shard, rootShard *operatorv1alpha1.RootShard, kcpVW *operatorv1alpha1.VirtualWorkspace) reconciling.NamedDeploymentReconcilerFactory {
+func DeploymentReconciler(shard *operatorv1alpha1.Shard, rootShard *operatorv1alpha1.RootShard, kcpVW *operatorv1alpha1.VirtualWorkspace, shards []operatorv1alpha1.Shard) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return resources.GetShardDeploymentName(shard), func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			labels := resources.GetShardResourceLabels(shard)
@@ -224,7 +224,7 @@ func DeploymentReconciler(shard *operatorv1alpha1.Shard, rootShard *operatorv1al
 			dep = utils.ApplyCommonShardDeploymentProperties(dep)
 			dep = utils.ApplyCommonShardConfig(dep, &shard.Spec.CommonShardSpec)
 			dep = utils.ApplyDeploymentTemplate(dep, shard.Spec.DeploymentTemplate)
-			dep = utils.ApplyAuthConfiguration(dep, shard.Spec.Auth, rootShard)
+			dep = utils.ApplyAuthConfiguration(dep, shard.Spec.Auth, rootShard, shards)
 
 			// If shard has bundle annotation, store desired replicas in annotation then scale deployment to 0 locally
 			if shard.Annotations != nil && shard.Annotations[resources.BundleAnnotation] != "" {

--- a/internal/resources/shard/deployment_test.go
+++ b/internal/resources/shard/deployment_test.go
@@ -307,7 +307,7 @@ func TestDeploymentReconciler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			factory := DeploymentReconciler(tt.shard, tt.rootShard, nil)
+			factory := DeploymentReconciler(tt.shard, tt.rootShard, nil, nil)
 			name, reconcilerFunc := factory()
 
 			assert.Equal(t, tt.expectedName, name)

--- a/internal/resources/utils/authentication.go
+++ b/internal/resources/utils/authentication.go
@@ -21,7 +21,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kcp-dev/kcp-operator/internal/resources"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
@@ -81,7 +80,7 @@ func applyOIDCConfiguration(deployment *appsv1.Deployment, config operatorv1alph
 	return deployment
 }
 
-func applyServiceAccountAuthentication(deployment *appsv1.Deployment, rootShard *operatorv1alpha1.RootShard) *appsv1.Deployment {
+func applyServiceAccountAuthentication(deployment *appsv1.Deployment, rootShard *operatorv1alpha1.RootShard, shards []operatorv1alpha1.Shard) *appsv1.Deployment {
 	// Secrets and volumes
 
 	volumes := []corev1.Volume{}
@@ -103,17 +102,19 @@ func applyServiceAccountAuthentication(deployment *appsv1.Deployment, rootShard 
 		MountPath: fmt.Sprintf("/etc/kcp/tls/%s/%s", rootShard.Name, string(operatorv1alpha1.ServiceAccountCertificate)),
 	})
 
-	for _, shard := range rootShard.Status.Shards {
+	for _, shard := range shards {
+		certName := resources.GetShardCertificateName(&shard, operatorv1alpha1.ServiceAccountCertificate)
+
 		volumes = append(volumes, corev1.Volume{
-			Name: resources.GetShardCertificateName(&operatorv1alpha1.Shard{ObjectMeta: metav1.ObjectMeta{Name: shard.Name}}, operatorv1alpha1.ServiceAccountCertificate),
+			Name: certName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: resources.GetShardCertificateName(&operatorv1alpha1.Shard{ObjectMeta: metav1.ObjectMeta{Name: shard.Name}}, operatorv1alpha1.ServiceAccountCertificate),
+					SecretName: certName,
 				},
 			},
 		})
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      resources.GetShardCertificateName(&operatorv1alpha1.Shard{ObjectMeta: metav1.ObjectMeta{Name: shard.Name}}, operatorv1alpha1.ServiceAccountCertificate),
+			Name:      certName,
 			ReadOnly:  true,
 			MountPath: fmt.Sprintf("/etc/kcp/tls/%s/%s", shard.Name, string(operatorv1alpha1.ServiceAccountCertificate)),
 		})
@@ -128,7 +129,7 @@ func applyServiceAccountAuthentication(deployment *appsv1.Deployment, rootShard 
 	extraArgs = append(extraArgs, "--service-account-lookup=false")
 	extraArgs = append(extraArgs, fmt.Sprintf("--service-account-key-file=/etc/kcp/tls/%s/service-account/tls.crt", rootShard.Name))
 
-	for _, shard := range rootShard.Status.Shards {
+	for _, shard := range shards {
 		extraArgs = append(extraArgs, fmt.Sprintf("--service-account-key-file=/etc/kcp/tls/%s/service-account/tls.crt", shard.Name))
 	}
 

--- a/internal/resources/utils/authentication_test.go
+++ b/internal/resources/utils/authentication_test.go
@@ -35,6 +35,7 @@ func TestApplyServiceAccountAuthentication(t *testing.T) {
 	tests := []struct {
 		name           string
 		rootShard      *operatorv1alpha1.RootShard
+		shards         []operatorv1alpha1.Shard
 		initialDeploy  *appsv1.Deployment
 		validateDeploy func(*testing.T, *appsv1.Deployment)
 	}{
@@ -44,10 +45,8 @@ func TestApplyServiceAccountAuthentication(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-root-shard",
 				},
-				Status: operatorv1alpha1.RootShardStatus{
-					Shards: []operatorv1alpha1.ShardReference{},
-				},
 			},
+			shards: []operatorv1alpha1.Shard{},
 			initialDeploy: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-deployment",
@@ -98,12 +97,10 @@ func TestApplyServiceAccountAuthentication(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-root-shard",
 				},
-				Status: operatorv1alpha1.RootShardStatus{
-					Shards: []operatorv1alpha1.ShardReference{
-						{Name: "shard-1"},
-						{Name: "shard-2"},
-					},
-				},
+			},
+			shards: []operatorv1alpha1.Shard{
+				{ObjectMeta: metav1.ObjectMeta{Name: "shard-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "shard-2"}},
 			},
 			initialDeploy: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -172,11 +169,9 @@ func TestApplyServiceAccountAuthentication(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-root-shard",
 				},
-				Status: operatorv1alpha1.RootShardStatus{
-					Shards: []operatorv1alpha1.ShardReference{
-						{Name: "shard-1"},
-					},
-				},
+			},
+			shards: []operatorv1alpha1.Shard{
+				{ObjectMeta: metav1.ObjectMeta{Name: "shard-1"}},
 			},
 			initialDeploy: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -250,9 +245,6 @@ func TestApplyServiceAccountAuthentication(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-root-shard",
 				},
-				Status: operatorv1alpha1.RootShardStatus{
-					Shards: nil,
-				},
 			},
 			initialDeploy: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -290,7 +282,7 @@ func TestApplyServiceAccountAuthentication(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := applyServiceAccountAuthentication(tt.initialDeploy, tt.rootShard)
+			result := applyServiceAccountAuthentication(tt.initialDeploy, tt.rootShard, tt.shards)
 
 			require.NotNil(t, result)
 			assert.Equal(t, tt.initialDeploy, result, "Function should return the same deployment instance")
@@ -598,7 +590,7 @@ func TestApplyWebhookAuthentication(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ApplyAuthConfiguration(tt.initialDeploy, tt.authenticationSpec, nil)
+			result := ApplyAuthConfiguration(tt.initialDeploy, tt.authenticationSpec, nil, nil)
 
 			require.NotNil(t, result)
 			assert.Equal(t, tt.initialDeploy, result, "Function should return the same deployment instance")
@@ -614,7 +606,6 @@ func TestApplyWebhookAuthentication(t *testing.T) {
 func TestApplyFrontProxyAuthConfiguration(t *testing.T) {
 	rootShard := &operatorv1alpha1.RootShard{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-root-shard"},
-		Status:     operatorv1alpha1.RootShardStatus{Shards: []operatorv1alpha1.ShardReference{}},
 	}
 
 	newDeploy := func() *appsv1.Deployment {
@@ -639,7 +630,7 @@ func TestApplyFrontProxyAuthConfiguration(t *testing.T) {
 	t.Run("token auth file is applied", func(t *testing.T) {
 		dep := ApplyAuthConfiguration(newDeploy(), &operatorv1alpha1.AuthSpec{
 			TokenAuthFile: &operatorv1alpha1.TokenAuthFileSpec{SecretName: "test-token-auth"},
-		}, rootShard)
+		}, rootShard, nil)
 
 		args := dep.Spec.Template.Spec.Containers[0].Args
 		assert.Contains(t, args, "--token-auth-file=/etc/kcp/authentication/token/token.csv")

--- a/internal/resources/utils/deployments.go
+++ b/internal/resources/utils/deployments.go
@@ -93,9 +93,9 @@ func ApplyResources(container corev1.Container, resources *corev1.ResourceRequir
 }
 
 // ApplyAuthConfiguration applies the auth configuration to a deployment,
-// including ServiceAccount authentication, which loads every shard's
-// service-account public key.
-func ApplyAuthConfiguration(deployment *appsv1.Deployment, config *operatorv1alpha1.AuthSpec, rootShard *operatorv1alpha1.RootShard) *appsv1.Deployment {
+// including ServiceAccount authentication, which loads the service-account
+// public key of the root shard and of every shard in shards.
+func ApplyAuthConfiguration(deployment *appsv1.Deployment, config *operatorv1alpha1.AuthSpec, rootShard *operatorv1alpha1.RootShard, shards []operatorv1alpha1.Shard) *appsv1.Deployment {
 	if config == nil {
 		return deployment
 	}
@@ -113,7 +113,7 @@ func ApplyAuthConfiguration(deployment *appsv1.Deployment, config *operatorv1alp
 	}
 
 	if config.ServiceAccount != nil && config.ServiceAccount.Enabled {
-		deployment = applyServiceAccountAuthentication(deployment, rootShard)
+		deployment = applyServiceAccountAuthentication(deployment, rootShard, shards)
 	}
 
 	return deployment


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.md.

-->

## Summary

Part of the decoupling of configuration and workload.
For Compiled* CRs the Shards need to be gathered before configuring the workload resources.
Flow will be that the operator.kcp.io controllers set the shards in the deploy.operator.kcp.io CRs.

<!--
Please provide a description that explains *why* your PR is changing something
in the codebase, and focus less on what *what* you're changing. The following are
good questions to ask yourself when writing the PR summary:

* What are the problems you are trying to solve?
* What assumptions did you make when implementing your changes?
* Which workflows will be affected/improved by your change?
-->

## What Type of PR Is This?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

## Related Issue(s)
Fixes #

## Release Notes
<!--
Please add a release note in the block below.
Leave NONE only if no user-facing changes are in this PR.
-->
```release-note
NONE
```
