### PR TITLE
[1/6] Pass rootShardName and shardNames to ApplyAuthConfiguration instead of full objects

### DIFF
--- a/internal/resources/frontproxy/deployment.go
+++ b/internal/resources/frontproxy/deployment.go
@@ -226,7 +226,7 @@ func (r *reconciler) deploymentReconciler() reconciling.NamedDeploymentReconcile
 			dep = utils.ApplyDeploymentTemplate(dep, template)
 
 			if r.frontProxy != nil {
-				dep = utils.ApplyAuthConfiguration(dep, r.frontProxy.Spec.Auth, r.rootShard, r.shards)
+				dep = utils.ApplyAuthConfiguration(dep, r.frontProxy.Spec.Auth, r.rootShard.Name, utils.ShardNames(r.shards))
 
 				// If frontproxy has bundle annotation, store desired replicas in annotation then scale deployment to 0 locally
 				if r.frontProxy.Annotations != nil && r.frontProxy.Annotations[resources.BundleAnnotation] != "" {

--- a/internal/resources/rootshard/deployment.go
+++ b/internal/resources/rootshard/deployment.go
@@ -204,7 +204,7 @@ func DeploymentReconciler(rootShard *operatorv1alpha1.RootShard, kcpVW *operator
 			dep = utils.ApplyCommonShardDeploymentProperties(dep)
 			dep = utils.ApplyCommonShardConfig(dep, &rootShard.Spec.CommonShardSpec)
 			dep = utils.ApplyDeploymentTemplate(dep, rootShard.Spec.DeploymentTemplate)
-			dep = utils.ApplyAuthConfiguration(dep, rootShard.Spec.Auth, rootShard, shards)
+			dep = utils.ApplyAuthConfiguration(dep, rootShard.Spec.Auth, rootShard.Name, utils.ShardNames(shards))
 
 			// If rootshard has bundle annotation, store desired replicas in annotation then scale deployment to 0 locally
 			if rootShard.Annotations != nil && rootShard.Annotations[resources.BundleAnnotation] != "" {

--- a/internal/resources/shard/deployment.go
+++ b/internal/resources/shard/deployment.go
@@ -224,7 +224,7 @@ func DeploymentReconciler(shard *operatorv1alpha1.Shard, rootShard *operatorv1al
 			dep = utils.ApplyCommonShardDeploymentProperties(dep)
 			dep = utils.ApplyCommonShardConfig(dep, &shard.Spec.CommonShardSpec)
 			dep = utils.ApplyDeploymentTemplate(dep, shard.Spec.DeploymentTemplate)
-			dep = utils.ApplyAuthConfiguration(dep, shard.Spec.Auth, rootShard, shards)
+			dep = utils.ApplyAuthConfiguration(dep, shard.Spec.Auth, rootShard.Name, utils.ShardNames(shards))
 
 			// If shard has bundle annotation, store desired replicas in annotation then scale deployment to 0 locally
 			if shard.Annotations != nil && shard.Annotations[resources.BundleAnnotation] != "" {

--- a/internal/resources/utils/authentication.go
+++ b/internal/resources/utils/authentication.go
@@ -22,7 +22,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/kcp-dev/kcp-operator/internal/resources"
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
@@ -80,30 +79,32 @@ func applyOIDCConfiguration(deployment *appsv1.Deployment, config operatorv1alph
 	return deployment
 }
 
-func applyServiceAccountAuthentication(deployment *appsv1.Deployment, rootShard *operatorv1alpha1.RootShard, shards []operatorv1alpha1.Shard) *appsv1.Deployment {
+func applyServiceAccountAuthentication(deployment *appsv1.Deployment, rootShardName string, shardNames []string) *appsv1.Deployment {
 	// Secrets and volumes
 
 	volumes := []corev1.Volume{}
 	volumeMounts := []corev1.VolumeMount{}
 
 	// Root shard is not on the list, so we add it manually
+	rootShardCertName := fmt.Sprintf("%s-%s", rootShardName, operatorv1alpha1.ServiceAccountCertificate)
+
 	volumes = append(volumes, corev1.Volume{
-		Name: resources.GetRootShardCertificateName(rootShard, operatorv1alpha1.ServiceAccountCertificate),
+		Name: rootShardCertName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: resources.GetRootShardCertificateName(rootShard, operatorv1alpha1.ServiceAccountCertificate),
+				SecretName: rootShardCertName,
 			},
 		},
 	})
 
 	volumeMounts = append(volumeMounts, corev1.VolumeMount{
-		Name:      resources.GetRootShardCertificateName(rootShard, operatorv1alpha1.ServiceAccountCertificate),
+		Name:      rootShardCertName,
 		ReadOnly:  true,
-		MountPath: fmt.Sprintf("/etc/kcp/tls/%s/%s", rootShard.Name, string(operatorv1alpha1.ServiceAccountCertificate)),
+		MountPath: fmt.Sprintf("/etc/kcp/tls/%s/%s", rootShardName, string(operatorv1alpha1.ServiceAccountCertificate)),
 	})
 
-	for _, shard := range shards {
-		certName := resources.GetShardCertificateName(&shard, operatorv1alpha1.ServiceAccountCertificate)
+	for _, shardName := range shardNames {
+		certName := fmt.Sprintf("%s-%s", shardName, operatorv1alpha1.ServiceAccountCertificate)
 
 		volumes = append(volumes, corev1.Volume{
 			Name: certName,
@@ -116,7 +117,7 @@ func applyServiceAccountAuthentication(deployment *appsv1.Deployment, rootShard 
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      certName,
 			ReadOnly:  true,
-			MountPath: fmt.Sprintf("/etc/kcp/tls/%s/%s", shard.Name, string(operatorv1alpha1.ServiceAccountCertificate)),
+			MountPath: fmt.Sprintf("/etc/kcp/tls/%s/%s", shardName, string(operatorv1alpha1.ServiceAccountCertificate)),
 		})
 	}
 
@@ -127,10 +128,10 @@ func applyServiceAccountAuthentication(deployment *appsv1.Deployment, rootShard 
 
 	extraArgs := []string{}
 	extraArgs = append(extraArgs, "--service-account-lookup=false")
-	extraArgs = append(extraArgs, fmt.Sprintf("--service-account-key-file=/etc/kcp/tls/%s/service-account/tls.crt", rootShard.Name))
+	extraArgs = append(extraArgs, fmt.Sprintf("--service-account-key-file=/etc/kcp/tls/%s/service-account/tls.crt", rootShardName))
 
-	for _, shard := range shards {
-		extraArgs = append(extraArgs, fmt.Sprintf("--service-account-key-file=/etc/kcp/tls/%s/service-account/tls.crt", shard.Name))
+	for _, shardName := range shardNames {
+		extraArgs = append(extraArgs, fmt.Sprintf("--service-account-key-file=/etc/kcp/tls/%s/service-account/tls.crt", shardName))
 	}
 
 	podSpec.Containers[0].Args = append(podSpec.Containers[0].Args, extraArgs...)

--- a/internal/resources/utils/authentication_test.go
+++ b/internal/resources/utils/authentication_test.go
@@ -34,19 +34,15 @@ import (
 func TestApplyServiceAccountAuthentication(t *testing.T) {
 	tests := []struct {
 		name           string
-		rootShard      *operatorv1alpha1.RootShard
-		shards         []operatorv1alpha1.Shard
+		rootShardName  string
+		shardNames     []string
 		initialDeploy  *appsv1.Deployment
 		validateDeploy func(*testing.T, *appsv1.Deployment)
 	}{
 		{
-			name: "root shard only - no additional shards",
-			rootShard: &operatorv1alpha1.RootShard{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-root-shard",
-				},
-			},
-			shards: []operatorv1alpha1.Shard{},
+			name:          "root shard only - no additional shards",
+			rootShardName: "test-root-shard",
+			shardNames:    []string{},
 			initialDeploy: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-deployment",
@@ -92,16 +88,9 @@ func TestApplyServiceAccountAuthentication(t *testing.T) {
 			},
 		},
 		{
-			name: "root shard with multiple additional shards",
-			rootShard: &operatorv1alpha1.RootShard{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-root-shard",
-				},
-			},
-			shards: []operatorv1alpha1.Shard{
-				{ObjectMeta: metav1.ObjectMeta{Name: "shard-1"}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "shard-2"}},
-			},
+			name:          "root shard with multiple additional shards",
+			rootShardName: "test-root-shard",
+			shardNames:    []string{"shard-1", "shard-2"},
 			initialDeploy: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-deployment",
@@ -164,15 +153,9 @@ func TestApplyServiceAccountAuthentication(t *testing.T) {
 			},
 		},
 		{
-			name: "preserves existing volumes and volume mounts",
-			rootShard: &operatorv1alpha1.RootShard{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-root-shard",
-				},
-			},
-			shards: []operatorv1alpha1.Shard{
-				{ObjectMeta: metav1.ObjectMeta{Name: "shard-1"}},
-			},
+			name:          "preserves existing volumes and volume mounts",
+			rootShardName: "test-root-shard",
+			shardNames:    []string{"shard-1"},
 			initialDeploy: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-deployment",
@@ -240,12 +223,8 @@ func TestApplyServiceAccountAuthentication(t *testing.T) {
 			},
 		},
 		{
-			name: "empty shards list",
-			rootShard: &operatorv1alpha1.RootShard{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-root-shard",
-				},
-			},
+			name:          "empty shards list",
+			rootShardName: "test-root-shard",
 			initialDeploy: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-deployment",
@@ -282,7 +261,7 @@ func TestApplyServiceAccountAuthentication(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := applyServiceAccountAuthentication(tt.initialDeploy, tt.rootShard, tt.shards)
+			result := applyServiceAccountAuthentication(tt.initialDeploy, tt.rootShardName, tt.shardNames)
 
 			require.NotNil(t, result)
 			assert.Equal(t, tt.initialDeploy, result, "Function should return the same deployment instance")
@@ -590,7 +569,7 @@ func TestApplyWebhookAuthentication(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ApplyAuthConfiguration(tt.initialDeploy, tt.authenticationSpec, nil, nil)
+			result := ApplyAuthConfiguration(tt.initialDeploy, tt.authenticationSpec, "", nil)
 
 			require.NotNil(t, result)
 			assert.Equal(t, tt.initialDeploy, result, "Function should return the same deployment instance")
@@ -604,10 +583,6 @@ func TestApplyWebhookAuthentication(t *testing.T) {
 // authentication options (including token-auth-file) but never applies structured authentication
 // configuration (--authentication-config), which the front-proxy binary does not support.
 func TestApplyFrontProxyAuthConfiguration(t *testing.T) {
-	rootShard := &operatorv1alpha1.RootShard{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-root-shard"},
-	}
-
 	newDeploy := func() *appsv1.Deployment {
 		return &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-deployment"},
@@ -630,7 +605,7 @@ func TestApplyFrontProxyAuthConfiguration(t *testing.T) {
 	t.Run("token auth file is applied", func(t *testing.T) {
 		dep := ApplyAuthConfiguration(newDeploy(), &operatorv1alpha1.AuthSpec{
 			TokenAuthFile: &operatorv1alpha1.TokenAuthFileSpec{SecretName: "test-token-auth"},
-		}, rootShard, nil)
+		}, "test-root-shard", nil)
 
 		args := dep.Spec.Template.Spec.Containers[0].Args
 		assert.Contains(t, args, "--token-auth-file=/etc/kcp/authentication/token/token.csv")

--- a/internal/resources/utils/deployments.go
+++ b/internal/resources/utils/deployments.go
@@ -92,10 +92,19 @@ func ApplyResources(container corev1.Container, resources *corev1.ResourceRequir
 	return container
 }
 
+// ShardNames extracts the names of the given shards.
+func ShardNames(shards []operatorv1alpha1.Shard) []string {
+	names := make([]string, 0, len(shards))
+	for _, shard := range shards {
+		names = append(names, shard.Name)
+	}
+	return names
+}
+
 // ApplyAuthConfiguration applies the auth configuration to a deployment,
 // including ServiceAccount authentication, which loads the service-account
-// public key of the root shard and of every shard in shards.
-func ApplyAuthConfiguration(deployment *appsv1.Deployment, config *operatorv1alpha1.AuthSpec, rootShard *operatorv1alpha1.RootShard, shards []operatorv1alpha1.Shard) *appsv1.Deployment {
+// public key of the root shard and of every shard in shardNames.
+func ApplyAuthConfiguration(deployment *appsv1.Deployment, config *operatorv1alpha1.AuthSpec, rootShardName string, shardNames []string) *appsv1.Deployment {
 	if config == nil {
 		return deployment
 	}
@@ -113,7 +122,7 @@ func ApplyAuthConfiguration(deployment *appsv1.Deployment, config *operatorv1alp
 	}
 
 	if config.ServiceAccount != nil && config.ServiceAccount.Enabled {
-		deployment = applyServiceAccountAuthentication(deployment, rootShard, shards)
+		deployment = applyServiceAccountAuthentication(deployment, rootShardName, shardNames)
 	}
 
 	return deployment


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.md.

-->

## Summary

To make ApplyAuthConfiguration reusable for Compiled* resources.

<!--
Please provide a description that explains *why* your PR is changing something
in the codebase, and focus less on what *what* you're changing. The following are
good questions to ask yourself when writing the PR summary:

* What are the problems you are trying to solve?
* What assumptions did you make when implementing your changes?
* Which workflows will be affected/improved by your change?
-->

## What Type of PR Is This?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

## Related Issue(s)
Fixes #

## Release Notes
<!--
Please add a release note in the block below.
Leave NONE only if no user-facing changes are in this PR.
-->
```release-note
NONE
```
