### PR TITLE
[2/6] Make utils.GetFrontProxyExternalPort reusable

### DIFF
--- a/internal/resources/frontproxy/service.go
+++ b/internal/resources/frontproxy/service.go
@@ -39,7 +39,7 @@ func (r *reconciler) serviceName() string {
 func (r *reconciler) getExternalPort() int {
 	// We're reconciling a regular FrontProxy.
 	if r.frontProxy != nil {
-		return utils.GetFrontProxyExternalPort(r.frontProxy, r.rootShard)
+		return utils.GetFrontProxyExternalPort(r.frontProxy.Spec, r.rootShard.Spec)
 	}
 
 	// We're reconciling the rootshard's internal proxy.

--- a/internal/resources/utils/frontproxy.go
+++ b/internal/resources/utils/frontproxy.go
@@ -23,14 +23,14 @@ import (
 	operatorv1alpha1 "github.com/kcp-dev/kcp-operator/sdk/apis/operator/v1alpha1"
 )
 
-func GetFrontProxyExternalPort(fp *operatorv1alpha1.FrontProxy, r *operatorv1alpha1.RootShard) int {
+func GetFrontProxyExternalPort(fp operatorv1alpha1.FrontProxySpec, rootShard operatorv1alpha1.RootShardSpec) int {
 	// easy, the user explicitly configured an external port on the FrontProxy itself
-	if port := fp.Spec.External.Port; port > 0 {
+	if port := fp.External.Port; port > 0 {
 		return int(port)
 	}
 
 	// fallback to deprecated ExternalHostname
-	if extName := fp.Spec.ExternalHostname; extName != "" { //nolint:staticcheck
+	if extName := fp.ExternalHostname; extName != "" { //nolint:staticcheck
 		_, port, err := net.SplitHostPort(extName)
 		if err == nil {
 			parsed, err := strconv.Atoi(port)
@@ -44,10 +44,8 @@ func GetFrontProxyExternalPort(fp *operatorv1alpha1.FrontProxy, r *operatorv1alp
 	}
 
 	// if nothing valid is configured on the FrontProxy, check the RootShard
-	if r != nil {
-		if port := r.Spec.External.Port; port > 0 {
-			return int(port)
-		}
+	if port := rootShard.External.Port; port > 0 {
+		return int(port)
 	}
 
 	// last resort, fallback to the default kcp port


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.md.

-->

## Summary

Like #280 makes it easier to use for Compiled* reconcilers.

<!--
Please provide a description that explains *why* your PR is changing something
in the codebase, and focus less on what *what* you're changing. The following are
good questions to ask yourself when writing the PR summary:

* What are the problems you are trying to solve?
* What assumptions did you make when implementing your changes?
* Which workflows will be affected/improved by your change?
-->

## What Type of PR Is This?

/feat feature

<!--
Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

## Related Issue(s)
Fixes #

## Release Notes
<!--
Please add a release note in the block below.
Leave NONE only if no user-facing changes are in this PR.
-->
```release-note
NONE
```
