### PR TITLE
Add `--shard-external-url` and `--cache-kubeconfig` for VW again

### DIFF
--- a/internal/resources/compiledvirtualworkspace/deployment.go
+++ b/internal/resources/compiledvirtualworkspace/deployment.go
@@ -415,12 +415,15 @@ func getArgs(vw *deployv1alpha1.CompiledVirtualWorkspace) []string {
 		fmt.Sprintf("--kubeconfig=%s/kubeconfig", serverKubeconfigMountPath(vw)),
 	}
 
-	// Flags that are specific to one server implementation are deliberately not generated here --
-	// see TestVirtualWorkspaceArgumentSurface. kcp's own server takes `--shard-external-url` on
-	// versions before 0.31 and `--cache-kubeconfig` where a cache server is configured; both belong
-	// in spec.extraArgs, because only the operator's user knows which binary is running and which
-	// flags it understands. The operator still mounts the cache server's kubeconfig, since it alone
-	// knows the Secret's name.
+	// --shard-external-url is deprecated in v0.31 but before that a required but unused flag.
+	// TODO(ntnn): We need a way to shut this off if it isn't required.
+	args = append(args, "--shard-external-url=https://127.0.0.1:6443")
+
+	// --cache-kubeconfig is required for kcp's own virtual-workspace.
+	// TODO(ntnn): We need a way to shut this off if it isn't required.
+	if getEffectiveCacheRef(vw) != "" {
+		args = append(args, fmt.Sprintf("--cache-kubeconfig=%s/kubeconfig", getCacheServerKubeconfigMountPath()))
+	}
 
 	args = append(args, utils.GetLoggingArgs(vw.Spec.VirtualWorkspace.Logging)...)
 

--- a/internal/resources/compiledvirtualworkspace/deployment_test.go
+++ b/internal/resources/compiledvirtualworkspace/deployment_test.go
@@ -139,20 +139,6 @@ func TestDeploymentServerCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("implementation-specific flags are left to extraArgs", func(t *testing.T) {
-		// Generated for nobody, including kcp's own server: the operator cannot know which binary
-		// spec.command names, so a flag only some servers accept is the user's to pass.
-		for _, spec := range []operatorv1alpha1.VirtualWorkspaceSpec{
-			{},
-			{Command: []string{"/access-vw"}},
-		} {
-			container := reconcileDeployment(t, newCompiledVirtualWorkspace(spec)).Spec.Template.Spec.Containers[0]
-
-			assert.False(t, hasArgPrefix(container.Args, "--shard-external-url="))
-			assert.False(t, hasArgPrefix(container.Args, "--cache-kubeconfig="))
-		}
-	})
-
 	t.Run("the cache server kubeconfig is still mounted for extraArgs to point at", func(t *testing.T) {
 		dep := reconcileDeployment(t, newCompiledVirtualWorkspace(operatorv1alpha1.VirtualWorkspaceSpec{
 			Command: []string{"/access-vw"},
@@ -184,6 +170,8 @@ func TestVirtualWorkspaceArgumentSurface(t *testing.T) {
 		"--requestheader-group-headers",
 		"--requestheader-extra-headers-prefix",
 		"--kubeconfig",
+		"--shard-external-url",
+		"--cache-kubeconfig",
 	}
 
 	vw := newCompiledVirtualWorkspace(operatorv1alpha1.VirtualWorkspaceSpec{

--- a/test/e2e/virtualworkspaces/custom_test.go
+++ b/test/e2e/virtualworkspaces/custom_test.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"slices"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -314,17 +313,6 @@ func assertDeploymentShape(t *testing.T, ctx context.Context, workloadClient ctr
 	server := podSpec.Containers[0]
 	if got := server.Command; len(got) != 1 || got[0] != "/mock-virtualworkspace" {
 		t.Errorf("Server command is %v, expected the image's own entrypoint.", got)
-	}
-
-	// Flags that only some server implementations understand are never generated -- they belong in
-	// spec.extraArgs, where the user names the ones their binary actually takes. The mock would
-	// have refused to start, but assert it directly so the failure names the cause.
-	for _, arg := range server.Args {
-		for _, forbidden := range []string{"--shard-external-url", "--cache-kubeconfig"} {
-			if strings.HasPrefix(arg, forbidden) {
-				t.Errorf("Server was passed the implementation-specific flag %q.", arg)
-			}
-		}
 	}
 
 	// Each container sees its own credential and not the other's, nor the privileged fallback

--- a/test/mock-virtualworkspace/main.go
+++ b/test/mock-virtualworkspace/main.go
@@ -80,7 +80,9 @@ type options struct {
 	requestheaderExtraPrefix  []string
 
 	// Connection to kcp.
-	kubeconfig string
+	kubeconfig       string
+	cacheKubeconfig  string
+	shardExternalURL string
 
 	// Mock-specific, passed through spec.extraArgs / an init container's args.
 	mode           string
@@ -101,6 +103,8 @@ func main() {
 	fs.StringVar(&opts.bindAddress, "bind-address", "0.0.0.0", "")
 	fs.IntVar(&opts.securePort, "secure-port", 6443, "")
 	fs.StringVar(&opts.clientCAFile, "client-ca-file", "", "")
+	fs.StringVar(&opts.cacheKubeconfig, "cache-kubeconfig", "", "")
+	fs.StringVar(&opts.shardExternalURL, "shard-external-url", "", "")
 	fs.StringVar(&opts.requestheaderClientCAFile, "requestheader-client-ca-file", "", "")
 	fs.StringSliceVar(&opts.requestheaderAllowedNames, "requestheader-allowed-names", nil, "")
 	fs.StringSliceVar(&opts.requestheaderUsernames, "requestheader-username-headers", nil, "")


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.md.

-->

## Summary

Fix #289; it breaks e2e and we didn't notice due to an accidental merge.
The problem is that just omitting the flags will break existing deployment - we need a knob on the type to disable these if they aren't needed.

<!--
Please provide a description that explains *why* your PR is changing something
in the codebase, and focus less on what *what* you're changing. The following are
good questions to ask yourself when writing the PR summary:

* What are the problems you are trying to solve?
* What assumptions did you make when implementing your changes?
* Which workflows will be affected/improved by your change?
-->

## What Type of PR Is This?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

## Related Issue(s)
Fixes #

## Release Notes
<!--
Please add a release note in the block below.
Leave NONE only if no user-facing changes are in this PR.
-->
```release-note
UNBREAKING: reverted stop adding  `--shard-external-url` and `--cache-kubeconfig` as required flags to VirtualWorkspaces and make them user-providable only
```
